### PR TITLE
make roles upgradeable

### DIFF
--- a/projects/gnoland/gno.land/p/eve000/event/agenda/agenda.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/agenda/agenda.gno
@@ -15,7 +15,7 @@ type Agenda struct {
 	Location       *location.Location
 	StartDate      time.Time
 	EndDate        time.Time
-	KeynoteHeading *component.Content
+	Banner *component.Content
 	Description    string
 	Sessions       []*session.Session
 	renderOpts     *component.RenderOpts
@@ -23,8 +23,8 @@ type Agenda struct {
 
 var _ component.Component = (*Agenda)(nil)
 
-func (a *Agenda) SetKeynoteHeading(heading *component.Content) {
-	a.KeynoteHeading = heading
+func (a *Agenda) SetBanner(heading *component.Content) {
+	a.Banner = heading
 }
 
 func (a *Agenda) ToAnchor() string {
@@ -44,8 +44,8 @@ func (a *Agenda) ToMarkdown() string {
 	}
 	markdown += a.Description + "\n\n"
 
-	if a.KeynoteHeading != nil && a.KeynoteHeading.Published {
-		markdown += a.KeynoteHeading.Markdown + "\n\n"
+	if a.Banner != nil && a.Banner.Published {
+		markdown += a.Banner.Markdown + "\n\n"
 	}
 
 	markdown += "## Agenda \n\n"

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/acl.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/acl.gno
@@ -9,11 +9,13 @@ import (
 )
 
 var (
-	organizers *avl.Tree
-	speakers   *avl.Tree
-	attendees  *avl.Tree
-	proposers  *avl.Tree
-	reviewers  *avl.Tree
+	waitlist     *avl.Tree
+	organizers   *avl.Tree
+	speakers     *avl.Tree
+	attendees    *avl.Tree
+	proposers    *avl.Tree
+	reviewers    *avl.Tree
+	accessChecks map[string]func(string) bool
 )
 
 const (
@@ -22,6 +24,8 @@ const (
 )
 
 func init() {
+	waitlist = avl.NewTree()
+
 	reviewers = avl.NewTree()
 	reviewers.Set("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t", struct{}{})
 	reviewers.Set("g1aa5umzchlwqxtdfh58exmydmzsgpzcg3u9egcp", struct{}{})
@@ -50,6 +54,29 @@ func init() {
 	attendees.Set("g1yfts8fy9jyfeca4p42em6mcttfwcypkpkfx0rv", struct{}{})
 	attendees.Set("g140pp6d0wnmpjdrwk2npsz5ay4pwc0374vdvdyt", struct{}{})
 	attendees.Set("g1e8vw6gh284q7ggzqs8ne6r8j9aqhnmvl6rzzmz", struct{}{})
+
+	accessChecks = map[string]func(string) bool{
+		"waitlist":  waitlist.Has,
+		"proposer":  proposers.Has,
+		"reviewer":  reviewers.Has,
+		"attendee":  attendees.Has,
+		"speaker":   speakers.Has,
+		"organizer": organizers.Has,
+	}
+}
+
+// JoinWaitlist sets the address of the previous realm as an waitlist attendee
+// for the event.
+func JoinWaitlist() {
+	crossing()
+	waitlist.Set(string(std.PreviousRealm().Address()), struct{}{})
+}
+
+// RemoveSelfFromWaitlist removes the address of the previous realm as a waitlist attendee
+// for the event.
+func RemoveSelfFromWaitlist() {
+	crossing()
+	waitlist.Remove(string(std.PreviousRealm().Address()))
 }
 
 // JoinAsAttendee sets the address of the previous realm as an attendee
@@ -126,25 +153,47 @@ func RemoveReviewer(addr, sender std.Address) {
 	reviewers.Remove(string(addr))
 }
 
+// RoleExists takes a role and returns a boolean value that indicates whether or not
+// that role exists in the accessChecks map. It returns false if any other role type is requested.
+func RoleExists(role string) bool {
+	crossing()
+	if _, ok := accessChecks[role]; ok {
+		return true
+	}
+	return false
+}
+
 // HasRole takes a role and an address and returns a boolean value that indicates whether or not
 // that address is a member of one of three supported roles, `attendee`, `speaker`, and `organizer`.
 // It returns false if any other role type is requested.
 func HasRole(role string, addr std.Address) bool {
 	crossing()
-	switch role {
-	case "proposer":
-		return proposers.Has(string(addr))
-	case "reviewer":
-		return reviewers.Has(string(addr))
-	case "attendee":
-		return attendees.Has(string(addr))
-	case "speaker":
-		return speakers.Has(string(addr))
-	case "organizer":
-		return organizers.Has(string(addr))
-	default:
-		return false
+	if fn, ok := accessChecks[role]; ok {
+		return fn(string(addr))
 	}
+	return false
+}
+
+// ListRoles returns a slice of strings that contains all the roles in the accessChecks map.
+func ListRoles() []string {
+	crossing()
+	roles := make([]string, 0)
+	for role := range accessChecks {
+		roles = append(roles, role)
+	}
+	return roles
+}
+
+// SetRoleHandler takes a role and a function that takes an address and returns a boolean value.
+func SetRoleHandler(role string, fn func(string) bool) {
+	AssertAdminAccess()
+	accessChecks[role] = fn
+}
+
+// UnsetRoleHandler takes a role and removes it from the accessChecks map.
+func UnsetRoleHandler(role string) {
+	AssertAdminAccess()
+	delete(accessChecks, role)
 }
 
 func AssertAtLeastRole(role string, sender std.Address) {
@@ -165,18 +214,32 @@ func RenderAcl(path string) string {
 
 	return ufmt.Sprintf(`# `+evt.Name+`
 
-Event organizer and attendee list.
+Event access control lists.
 
-This realm can check membership by Querying [HasRole(role, addr)](gnolandlaunch:access-control$help#func-HasRole), where
-a role can be attendee, speaker, or organizer.
+This realm can check membership by Querying [HasRole(role, addr)](./gnolandlaunch$help#func-HasRole), where
+a role can be proposer, reviewer, attendee, speaker, or organizer.
 
 Note: This renderer will only display up to 100 addresses per group.
 
 ## Easy Actions:
 
+- [Join Waitlist](%v)
+- [Remove yourself from Waitlist](%v)
+
 - [Join as an Attendee](%v)
 - [Remove yourself as an Attendee](%v)
 
+## Waitlist
+
+%v
+
+## Proposers
+
+%v
+
+## Reviewers
+
+%v
 
 ## Organizers
 
@@ -189,10 +252,14 @@ Note: This renderer will only display up to 100 addresses per group.
 ## Attendees
 
 %v
-
 `,
+		txlink.NewLink("JoinWaitlist").URL(),
+		txlink.NewLink("RemoveSelfFromWaitlist").URL(),
 		txlink.NewLink("JoinAsAttendee").URL(),
 		txlink.NewLink("RemoveSelfAsAttendee").URL(),
+		toMDList(treeToSlice(waitlist)),
+		toMDList(treeToSlice(proposers)),
+		toMDList(treeToSlice(reviewers)),
 		toMDList(treeToSlice(organizers)),
 		toMDList(treeToSlice(speakers)),
 		toMDList(treeToSlice(attendees)))

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/acl.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/acl.gno
@@ -2,6 +2,7 @@ package event
 
 import (
 	"std"
+	"strings"
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
@@ -16,6 +17,7 @@ var (
 	proposers    *avl.Tree
 	reviewers    *avl.Tree
 	accessChecks map[string]func(string) bool
+	aclOverride  map[string]bool
 )
 
 const (
@@ -24,6 +26,7 @@ const (
 )
 
 func init() {
+    aclOverride = make(map[string]bool)
 	waitlist = avl.NewTree()
 
 	reviewers = avl.NewTree()
@@ -55,6 +58,67 @@ func init() {
 	attendees.Set("g140pp6d0wnmpjdrwk2npsz5ay4pwc0374vdvdyt", struct{}{})
 	attendees.Set("g1e8vw6gh284q7ggzqs8ne6r8j9aqhnmvl6rzzmz", struct{}{})
 
+	accessChecks = map[string]func(string) bool{
+		"waitlist":  waitlist.Has,
+		"proposer":  proposers.Has,
+		"reviewer":  reviewers.Has,
+		"attendee":  attendees.Has,
+		"speaker":   speakers.Has,
+		"organizer": organizers.Has,
+	}
+}
+
+// Use Admin access to set the role of an address.
+func AdminSetRole(role string, addr std.Address) {
+	AssertAdminAccess()
+	switch role {
+	case "waitlist":
+		waitlist.Set(string(addr), struct{}{})
+	case "attendee":
+		attendees.Set(string(addr), struct{}{})
+	case "speaker":
+		speakers.Set(string(addr), struct{}{})
+	case "organizer":
+		organizers.Set(string(addr), struct{}{})
+	case "proposer":
+		proposers.Set(string(addr), struct{}{})
+	case "reviewer":
+		reviewers.Set(string(addr), struct{}{})
+	default:
+		panic(ufmt.Sprintf("error: role %s not supported", role))
+	}
+}
+
+// AdminRemoveRole removes the address from the specified role.
+func AdminRemoveRole(role string, addr std.Address) {
+	AssertAdminAccess()
+	switch role {
+	case "waitlist":
+		waitlist.Remove(string(addr))
+	case "attendee":
+		attendees.Remove(string(addr))
+	case "speaker":
+		speakers.Remove(string(addr))
+	case "organizer":
+		organizers.Remove(string(addr))
+	case "proposer":
+		proposers.Remove(string(addr))
+	case "reviewer":
+		reviewers.Remove(string(addr))
+	default:
+		panic(ufmt.Sprintf("error: role %s not supported", role))
+	}
+}
+
+// ResetRoles resets all roles to empty trees and re-initializes the accessChecks map.
+func ResetRoles() {
+	AssertAdminAccess()
+	waitlist = avl.NewTree()
+	organizers = avl.NewTree()
+	speakers = avl.NewTree()
+	attendees = avl.NewTree()
+	proposers = avl.NewTree()
+	reviewers = avl.NewTree()
 	accessChecks = map[string]func(string) bool{
 		"waitlist":  waitlist.Has,
 		"proposer":  proposers.Has,
@@ -186,6 +250,7 @@ func ListRoles() []string {
 
 // SetRoleHandler takes a role and a function that takes an address and returns a boolean value.
 func SetRoleHandler(role string, fn func(string) bool) {
+    aclOverride[role] = true
 	AssertAdminAccess()
 	accessChecks[role] = fn
 }
@@ -211,58 +276,69 @@ func RenderAcl(path string) string {
 	if evt.Name == "" {
 		panic(ufmt.Sprintf("error: event with id %d not found", id))
 	}
+	var sb strings.Builder
+	sb.WriteString(ufmt.Sprintf(`# `+evt.Name+`
 
-	return ufmt.Sprintf(`# `+evt.Name+`
-
-Event access control lists.
+## Event access control
 
 This realm can check membership by Querying [HasRole(role, addr)](./gnolandlaunch$help#func-HasRole), where
 a role can be proposer, reviewer, attendee, speaker, or organizer.
 
 Note: This renderer will only display up to 100 addresses per group.
 
-## Easy Actions:
+### Easy Actions
 
 - [Join Waitlist](%v)
 - [Remove yourself from Waitlist](%v)
 
 - [Join as an Attendee](%v)
 - [Remove yourself as an Attendee](%v)
-
-## Waitlist
-
-%v
-
-## Proposers
-
-%v
-
-## Reviewers
-
-%v
-
-## Organizers
-
-%v
-
-## Speakers
-
-%v
-
-## Attendees
-
-%v
 `,
 		txlink.NewLink("JoinWaitlist").URL(),
 		txlink.NewLink("RemoveSelfFromWaitlist").URL(),
 		txlink.NewLink("JoinAsAttendee").URL(),
-		txlink.NewLink("RemoveSelfAsAttendee").URL(),
-		toMDList(treeToSlice(waitlist)),
-		toMDList(treeToSlice(proposers)),
-		toMDList(treeToSlice(reviewers)),
-		toMDList(treeToSlice(organizers)),
-		toMDList(treeToSlice(speakers)),
-		toMDList(treeToSlice(attendees)))
+		txlink.NewLink("RemoveSelfAsAttendee").URL()))
+
+    sb.WriteString("## Roles")
+	for role, _ := range accessChecks {
+		list := renderList(role)
+		if list != "" {
+			sb.WriteString(ufmt.Sprintf("\n%s\n", renderList(role)))
+		}
+	}
+
+	return sb.String()
+}
+
+func renderList(role string) string {
+	var sb strings.Builder
+	sb.WriteString(ufmt.Sprintf("\n### %s \n", role))
+	var addrs []std.Address
+	if aclOverride[role] {
+        sb.WriteString(ufmt.Sprintf("This role has a custom ACL handler.\n"))
+        return sb.String()
+    }
+	switch role {
+	case "waitlist":
+		addrs = treeToSlice(waitlist)
+	case "attendee":
+		addrs = treeToSlice(attendees)
+	case "speaker":
+		addrs = treeToSlice(speakers)
+	case "organizer":
+		addrs = treeToSlice(organizers)
+	case "proposer":
+		addrs = treeToSlice(proposers)
+	case "reviewer":
+		addrs = treeToSlice(reviewers)
+	default:
+		return ""
+	}
+	if len(addrs) == 0 {
+		return ""
+	}
+	sb.WriteString(toMDList(addrs))
+	return sb.String()
 }
 
 // treeToSlice takes an AVL tree and returns up to 100 items in order of index.

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/api.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/api.gno
@@ -4,7 +4,9 @@ import (
 	"std"
 	"strconv"
 	"strings"
+	"net/url"
 
+	"gno.land/p/moul/txlink"
 	"gno.land/p/demo/ufmt"
 	"gno.land/p/eve000/event"
 	"gno.land/p/eve000/event/component"
@@ -25,9 +27,11 @@ var (
 		Published: false,
 		Markdown:  "This page has been disabled",
 	}
-	keynoteHeading = &component.Content{
-		Published: false,
-		Markdown:  `#### Keynote\n\n TODO: update with patch001`,
+	banner = &component.Content{
+		Published: true,
+		Markdown:  "\n\n#### Status: Accepting Session Proposals\n\n" +
+		"Join us on [discord](https://discord.gg/YFtMjWwUN7) to get access to submit a proposal.\n\n" +
+		"or\n\n" + txlinkButton("Register To Attend", "JoinWaitlist"),
 	}
 	renderOpts = &component.RenderOpts{
 		Location: false,
@@ -91,7 +95,7 @@ func Render(path string) (out string) {
 			panic(ufmt.Sprintf("error: event with id %d not found", id))
 		} else {
 			agenda := evt.Agenda()
-			agenda.SetKeynoteHeading(keynoteHeading) // TODO: refactor to pass into agenda constructor
+			agenda.SetBanner(banner) // inject banner
 			return component.RenderComponent(path, agenda)
 		}
 	default:
@@ -154,8 +158,8 @@ func Unpublish(key string) {
 		eventMap.Published = false
 	case "published":
 		staticContent.Published = false
-	case "keynote":
-		keynoteHeading.Published = false
+	case "banner":
+		banner.Published = false
 	default:
 		panic("invalid key: " + key)
 	}
@@ -170,9 +174,9 @@ func SetContent(key, markdown string) {
 	case "published":
 		staticContent.SetPublished(true)
 		staticContent.SetMarkdown(markdown)
-	case "keynote":
-		keynoteHeading.SetPublished(true)
-		keynoteHeading.SetMarkdown(markdown)
+	case "banner":
+		banner.SetPublished(true)
+		banner.SetMarkdown(markdown)
 	default:
 		panic("invalid key: " + key)
 	}
@@ -230,6 +234,7 @@ func HasAllowedPrefix() bool {
 }
 
 // AssertAdminAccess panics if the caller's realm does not match the allowed prefix.
+// This is used to restrict access to certain functions intended to be used by patch-realm admins.
 func AssertAdminAccess() {
 	if !HasAllowedPrefix() {
 		panic("access denied: " + std.CurrentRealm().PkgPath() +
@@ -468,4 +473,29 @@ func AddSessionTags(eventId, sessionId int, tags ...string) {
 func SetEventMapContent(markdown string) {
 	AssertAdminAccess()
 	eventMap.Markdown = markdown
+}
+
+func txlinkButton(label, method string) string {
+    return button(label, txlink.NewLink(method).URL())
+}
+
+// render svg button in markdown
+func button(label, path string) string {
+    w := len(label)*9
+
+    svgButton := `<svg xmlns="http://www.w3.org/2000/svg" width="` + strconv.Itoa(w) + `" height="32" viewBox="0 0 ` + strconv.Itoa(w) + ` 34">
+<defs>
+  <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+    <feOffset result="offOut" in="SourceAlpha" dx="2" dy="2" />
+    <feGaussianBlur result="blurOut" in="offOut" stdDeviation="2" />
+    <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />
+  </filter>
+</defs>
+<rect x="-4" y="0" width="` + strconv.Itoa(w+4) + `" height="30" fill="#f0f0f0" stroke="#cccccc" stroke-width="1" rx="4" ry="4" filter="url(#shadow)"/>
+<text x="23" y="22" font-family="Arial, sans-serif" font-size="16" fill="#000000">` + label + `</text>
+</svg>`
+
+    dataUrl := "data:image/svg+xml;utf8," + url.PathEscape(svgButton)
+
+    return "[![" + label + "](" + dataUrl + ")](" + path + ")"
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/api.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/api.gno
@@ -229,6 +229,7 @@ func HasAllowedPrefix() bool {
 	return false
 }
 
+// AssertAdminAccess panics if the caller's realm does not match the allowed prefix.
 func AssertAdminAccess() {
 	if !HasAllowedPrefix() {
 		panic("access denied: " + std.CurrentRealm().PkgPath() +


### PR DESCRIPTION
- extends access-control page to show all configured roles
- only shows all roles with members on :access-control page
- adds a registration button for users to add themselves to waitlist
- allows using AdminAccess (via patching) to change HasRole handlers