### PR TITLE
feat: add new homepage + redirect

### DIFF
--- a/projects/gnoland/Dockerfile
+++ b/projects/gnoland/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gnolang/gno/gnodev:0.0.1-a3237eb57-master
+FROM ghcr.io/gnolang/gno/gnodev:0.0.1-f8e57320d-master
 
 RUN apk add --no-cache ca-certificates bash
 

--- a/projects/gnoland/Makefile
+++ b/projects/gnoland/Makefile
@@ -26,4 +26,6 @@ test: build
 # Add paths that you want tested here
 test-all: build
 	@make test path=gno.land/r/linker000/... && \
-	make test path=gno.land/p/eve000/...
+	make test path=gno.land/p/eve000/... && \
+	make test path=gno.land/r/buidlthefuture000/... && \
+	make test path=gno.land/r/labs000/...

--- a/projects/gnoland/caddy/Caddyfile
+++ b/projects/gnoland/caddy/Caddyfile
@@ -47,6 +47,12 @@ Disallow: /`
     import block_crawlers
     import add_noindex_header
 
+    # Redirect root to home realm
+    @root {
+        path /
+    }
+    redir @root /r/labs000/home permanent
+
     # Proxy to gnodev web
     reverse_proxy labsnet.internal:8888
 

--- a/projects/gnoland/docker-compose.yaml
+++ b/projects/gnoland/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
       - ./gno.land/p/eve000:/gnoroot/examples/gno.land/p/eve000
       - ./gno.land/r/linker000:/gnoroot/examples/gno.land/r/linker000
       - ./gno.land/r/buidlthefuture000:/gnoroot/examples/gno.land/r/buidlthefuture000
+      - ./gno.land/r/labs000:/gnoroot/examples/gno.land/r/labs000
     environment:
       - GNO_HOME=/gnoroot
     command: ["dev"]

--- a/projects/gnoland/gno.land/r/labs000/home/gnomod.toml
+++ b/projects/gnoland/gno.land/r/labs000/home/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/labs000/home"
+gno = "0.9"

--- a/projects/gnoland/gno.land/r/labs000/home/home.gno
+++ b/projects/gnoland/gno.land/r/labs000/home/home.gno
@@ -1,0 +1,29 @@
+package home
+
+func Render(_ string) string {
+	return `# Welcome to the All in Bits LabsNet!
+
+Welcome to the experimental Labs Net testnet - a playground for innovation and testing on the Gno blockchain.
+
+## What is Labs Net?
+
+Labsnet is an ephemeral testnet run by the All In Bits Labs team is designed flexible environment for sharing our work with the public.
+
+Labs Net is our dedicated testnet environment:
+
+- **Experiment** with smart contracts and realms
+- **Test** new features and implementations
+- **Deploy** and interact with Gno packages
+- **Innovate** without mainnet constraints
+
+## Coming Soon
+
+We're actively developing new features and resources for Labs Net. Stay tuned for:
+
+- Enhanced developer tools
+- Tutorial content
+- Sample applications
+- Community showcases
+
+`
+}


### PR DESCRIPTION
Quick update to add homepage for aiblabs.net


- CHANGED `gno.land` to latest build from `master`
- ADDED paths to `Makefile`
- ADDED redirect to Caddyfile to ensure labs000/home is homepage
- ADDED `r/labs000/home` for home page placeholder