### PR TITLE
Gnocal ux errors

### DIFF
--- a/projects/gnocal/gnocal.go
+++ b/projects/gnocal/gnocal.go
@@ -42,10 +42,7 @@ func NewGnocalServer(config *ServerOptions) *Server {
 	s.router.Use(middleware.Logger)
 	s.router.Use(middleware.Recoverer)
 
-	s.router.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("navigate to /{GNO.LAND REALM PATH}?{QUERY PARAMETERS} to get your calendar"))
-	})
-
+	s.router.Get("/", s.RenderLandingPage)
 	s.router.Get("/*", s.RenderCalFromRealm)
 
 	return s
@@ -79,4 +76,83 @@ func (s *Server) RenderCalFromRealm(w http.ResponseWriter, r *http.Request) {
 		out = removedRParen
 	}
 	w.Write([]byte(strings.ReplaceAll(out, `\n`, "\n")))
+}
+
+func (s *Server) RenderLandingPage(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html")
+	w.Write([]byte(`
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>gnocal :: decentralized calendar gateway</title>
+	<style>
+		body {
+			font-family: monospace;
+			background-color: #fefefe;
+			color: #222;
+			padding: 3em;
+			line-height: 1.6;
+		}
+		code {
+			background: #eee;
+			padding: 0.2em 0.4em;
+			border-radius: 4px;
+		}
+		h1 {
+			font-size: 2em;
+			margin-bottom: 0.2em;
+			border-bottom: 1px dashed #ccc;
+			padding-bottom: 0.5em;
+		}
+		.container {
+			max-width: 700px;
+			margin: auto;
+		}
+		footer {
+			margin-top: 3em;
+			font-size: 0.9em;
+			color: #888;
+		}
+		a {
+			color: #007acc;
+			text-decoration: none;
+		}
+		a:hover {
+			text-decoration: underline;
+		}
+	</style>
+</head>
+<body>
+	<div class="container">
+		<h1>gnocal :: gateway to your realm's events</h1>
+		<p>
+			<strong>gnocal</strong> connects user-generated events on <code>gno.land</code> to the calendars people already use — like Google Calendar, Apple Calendar, or any app that supports the <code>.ics</code> format.
+		</p>
+
+		<p>
+			It works like this: a gno.land realm defines a function called <code>RenderCal</code> with type signature <code>func RenderCal(path string) string</code>, which returns a calendar in the valid <code>.ics</code> format. gnocal will use its <em>gnoweb rpc client</em> to <code>QEval</code> the gno.land blockchain. Then, the <em>gnocal server</em> gives this back to you as a response of <code>[]byte</code>, so others can <em>subscribe</em> to the calendar using that link or download the response directly as an <code>.ics</code> file.
+		</p>
+
+		<p>
+			To use gnocal, just visit a URL like:
+		</p>
+
+		<pre><code>https://gnocal.aiblabs.net/gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar?format=ics</code></pre>
+
+		<p>
+			Then copy that link into your calendar app as a subscription. Your users will automatically see updates to your realm's events, right in their calendar.
+		</p>
+
+		<p>
+			As you try to build a path on <code>https://gnocal.aiblabs.net/</code>, there will be helpful colored error messages assiting you on where you want to go. 
+		</p>
+
+		<footer>
+			<em>gnocal is a project by aiblabs — built for the decentralized web.</em>
+		</footer>
+	</div>
+</body>
+</html>
+	`))
 }

--- a/projects/gnocal/gnocal.go
+++ b/projects/gnocal/gnocal.go
@@ -3,7 +3,9 @@ package gnocal
 // use chi v5 for server routing
 
 import (
+	"embed"
 	"fmt"
+	"html/template"
 	"net/http"
 	"strconv"
 	"strings"
@@ -15,6 +17,9 @@ import (
 )
 
 var f = fmt.Sprintf
+
+//go:embed static/*
+var static embed.FS
 
 type Server struct {
 	router    *chi.Mux
@@ -42,6 +47,8 @@ func NewGnocalServer(config *ServerOptions) *Server {
 	s.router.Use(middleware.Logger)
 	s.router.Use(middleware.Recoverer)
 
+	s.router.Handle("/static/*", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
+
 	s.router.Get("/", s.RenderLandingPage)
 	s.router.Get("/*", s.RenderCalFromRealm)
 
@@ -64,8 +71,66 @@ func (s *Server) RenderCalFromRealm(w http.ResponseWriter, r *http.Request) {
 	path := strconv.Quote("?" + r.URL.RawQuery) // e.g. "?" + "apple=2&session=1&session=100&session=0&format=json"
 	stringToken, _, err := s.gnoClient.QEval(calendarPath, f(`RenderCal(%s)`, path))
 	if err != nil {
-		http.Error(w, "QEval error: "+err.Error(), http.StatusInternalServerError)
-		return
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusInternalServerError)
+
+		errStr := err.Error()
+		switch {
+
+		case strings.Contains(errStr, "connect: connection refused"):
+			tmpl, parseErr := template.ParseFS(static, "static/connection_refused.html")
+			if parseErr != nil {
+				http.Error(w, "Template error", http.StatusInternalServerError)
+				return
+			}
+			tmpl.Execute(w, map[string]string{
+				"RpcUrl": s.config.GnolandRpcUrl,
+			})
+			return
+
+		case strings.Contains(errStr, "invalid package path"):
+			tmpl, parseErr := template.ParseFS(static, "static/invalid_realm_path.html")
+			if parseErr != nil {
+				http.Error(w, "Template error", http.StatusInternalServerError)
+				return
+			}
+			tmpl.Execute(w, map[string]string{
+				"InputPath": calendarPath,
+			})
+			return
+
+		case strings.Contains(errStr, "name RenderCal not declared"):
+			if _, _, renderErr := s.gnoClient.QEval(calendarPath, `Render("")`); renderErr == nil {
+				tmpl, parseErr := template.ParseFS(static, "static/rendercal_not_declared.html")
+				if parseErr != nil {
+					http.Error(w, "Template error", http.StatusInternalServerError)
+					return
+				}
+				tmpl.Execute(w, map[string]string{
+					"RealmPath": calendarPath,
+				})
+				return
+			}
+			tmpl, parseErr := template.ParseFS(static, "static/no_render_defined.html")
+			if parseErr != nil {
+				http.Error(w, "Template error", http.StatusInternalServerError)
+				return
+			}
+			tmpl.Execute(w, nil)
+			return
+
+		default:
+			tmpl, parseErr := template.ParseFS(static, "static/unknown_render_error.html")
+			if parseErr != nil {
+				http.Error(w, "Template error", http.StatusInternalServerError)
+				return
+			}
+			tmpl.Execute(w, map[string]string{
+				"InputPath":    calendarPath,
+				"ErrorMessage": errStr,
+			})
+			return
+		}
 	}
 
 	var out string // TODO: this is output post-processing, should be refactored out w/ better design
@@ -79,80 +144,12 @@ func (s *Server) RenderCalFromRealm(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) RenderLandingPage(w http.ResponseWriter, r *http.Request) {
+	content, err := static.ReadFile("static/landing_page.html")
+	if err != nil {
+		http.Error(w, "static/landing_page.html not found", http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "text/html")
-	w.Write([]byte(`
-<!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<title>gnocal :: decentralized calendar gateway</title>
-	<style>
-		body {
-			font-family: monospace;
-			background-color: #fefefe;
-			color: #222;
-			padding: 3em;
-			line-height: 1.6;
-		}
-		code {
-			background: #eee;
-			padding: 0.2em 0.4em;
-			border-radius: 4px;
-		}
-		h1 {
-			font-size: 2em;
-			margin-bottom: 0.2em;
-			border-bottom: 1px dashed #ccc;
-			padding-bottom: 0.5em;
-		}
-		.container {
-			max-width: 700px;
-			margin: auto;
-		}
-		footer {
-			margin-top: 3em;
-			font-size: 0.9em;
-			color: #888;
-		}
-		a {
-			color: #007acc;
-			text-decoration: none;
-		}
-		a:hover {
-			text-decoration: underline;
-		}
-	</style>
-</head>
-<body>
-	<div class="container">
-		<h1>gnocal :: gateway to your realm's events</h1>
-		<p>
-			<strong>gnocal</strong> connects user-generated events on <code>gno.land</code> to the calendars people already use — like Google Calendar, Apple Calendar, or any app that supports the <code>.ics</code> format.
-		</p>
-
-		<p>
-			It works like this: a gno.land realm defines a function called <code>RenderCal</code> with type signature <code>func RenderCal(path string) string</code>, which returns a calendar in the valid <code>.ics</code> format. gnocal will use its <em>gnoweb rpc client</em> to <code>QEval</code> the gno.land blockchain. Then, the <em>gnocal server</em> gives this back to you as a response of <code>[]byte</code>, so others can <em>subscribe</em> to the calendar using that link or download the response directly as an <code>.ics</code> file.
-		</p>
-
-		<p>
-			To use gnocal, just visit a URL like:
-		</p>
-
-		<pre><code>https://gnocal.aiblabs.net/gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar?format=ics</code></pre>
-
-		<p>
-			Then copy that link into your calendar app as a subscription. Your users will automatically see updates to your realm's events, right in their calendar.
-		</p>
-
-		<p>
-			As you try to build a path on <code>https://gnocal.aiblabs.net/</code>, there will be helpful colored error messages assiting you on where you want to go. 
-		</p>
-
-		<footer>
-			<em>gnocal is a project by aiblabs — built for the decentralized web.</em>
-		</footer>
-	</div>
-</body>
-</html>
-	`))
+	w.WriteHeader(http.StatusOK)
+	w.Write(content)
 }

--- a/projects/gnocal/static/connection_refused.html
+++ b/projects/gnocal/static/connection_refused.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>gnocal :: Connection Refused</title>
+  <link rel="stylesheet" href="/static/errors.css">
+</head>
+<body>
+  <div class="box">
+    <div class="error">✘ Could not connect to the Gno RPC server</div>
+    <p>This usually means the server is down or you are pointing to the wrong URL.</p>
+    <p><span class="label">Current RPC URL:</span> <span class="value">{{.RpcUrl}}</span></p>
+    <p>Make sure this URL is reachable and your <code>gnoland</code> node is running and listening at this address.</p>
+    <p>Try checking:</p>
+    <ul>
+      <li>That <code>gnoland</code> is running</li>
+      <li>That you can open <code>{{.RpcUrl}}/abci_info</code> in your browser</li>
+    </ul>
+    <p><a href="/">← Back to landing page</a></p>
+  </div>
+</body>
+</html>

--- a/projects/gnocal/static/errors.css
+++ b/projects/gnocal/static/errors.css
@@ -1,0 +1,79 @@
+body {
+  background-color: #1d2021;
+  color: #f2e5bc;
+  font-family: monospace;
+  padding: 2em;
+}
+.box {
+  border: 1px solid #928374;
+  padding: 1.5em;
+  background-color: #282828;
+  border-radius: 5px;
+  max-width: 800px;
+  margin: auto;
+}
+.error {
+  color: #fb4934;
+  font-weight: bold;
+  font-size: 1.2em;
+  margin-bottom: 1em;
+}
+.label {
+  color: #83a598;
+}
+.value {
+  color: #fabd2f;
+}
+a {
+  color: #8ec07c;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+code {
+  background-color: #3c3836;
+  color: #d3869b;
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+}
+ul {
+  margin-top: 0.5em;
+  margin-bottom: 1em;
+  padding-left: 1.5em;
+}
+li {
+  margin-bottom: 0.6em;
+}
+.comparison {
+  display: flex;
+  gap: 2em;
+  flex-wrap: wrap;
+  margin-top: 1em;
+  background-color: #1d2021;
+  border: 1px dashed #928374;
+  padding: 1em;
+  border-radius: 5px;
+}
+.column {
+  flex: 1;
+  min-width: 300px;
+}
+.column h3 {
+  color: #83a598;
+  border-bottom: 1px dashed #928374;
+  padding-bottom: 0.5em;
+  margin-bottom: 0.5em;
+}
+.example {
+  background-color: #3c3836;
+  padding: 0.5em;
+  border-radius: 4px;
+  color: #ebdbb2;
+  word-wrap: break-word;
+}
+.note {
+  font-size: 0.95em;
+  margin-top: 1em;
+  color: #bdae93;
+}

--- a/projects/gnocal/static/invalid_realm_path.html
+++ b/projects/gnocal/static/invalid_realm_path.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>gnocal :: Invalid Realm Path</title>
+  <link rel="stylesheet" href="/static/errors.css">
+</head>
+<body>
+  <div class="box">
+    <div class="error">✘ Invalid realm path</div>
+    <p>The path you entered doesn't match the required structure of a <code>gno.land</code> realm path.</p>
+
+    <div class="comparison">
+      <div class="column">
+        <h3>Your Input</h3>
+        <div class="example">{{.InputPath}}</div>
+      </div>
+      <div class="column">
+        <h3>Expected Format</h3>
+        <div class="example">gno.land/r/your_realm/your_module</div>
+      </div>
+    </div>
+
+    <p class="note">
+      A valid realm path must:
+      <ul>
+        <li>Start with <code>gno.land/</code></li>
+        <li>Include the <code>/r/</code> prefix to indicate a realm</li>
+        <li>Be followed by a valid path to a <code>.gno</code> file registered on the gno.land blockchain</li>
+        <li>That file should define a <code>func Render(path string) string</code> and <code>func RenderCal(path string) string</code> function</li>
+        <li>No slash ('/') at the end!</li>
+      </ul>
+    </p>
+
+    <p><a href="/">← Back to landing page</a></p>
+  </div>
+</body>
+</html>

--- a/projects/gnocal/static/landing_page.html
+++ b/projects/gnocal/static/landing_page.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>gnocal :: decentralized calendar gateway</title>
+	<style>
+		body {
+			font-family: monospace;
+			background-color: #fefefe;
+			color: #222;
+			padding: 3em;
+			line-height: 1.6;
+		}
+		code {
+			background: #eee;
+			padding: 0.2em 0.4em;
+			border-radius: 4px;
+		}
+		h1 {
+			font-size: 2em;
+			margin-bottom: 0.2em;
+			border-bottom: 1px dashed #ccc;
+			padding-bottom: 0.5em;
+		}
+		.container {
+			max-width: 700px;
+			margin: auto;
+		}
+		footer {
+			margin-top: 3em;
+			font-size: 0.9em;
+			color: #888;
+		}
+		a {
+			color: #007acc;
+			text-decoration: none;
+		}
+		a:hover {
+			text-decoration: underline;
+		}
+	</style>
+</head>
+<body>
+	<div class="container">
+		<h1>gnocal :: gateway to your realm's events</h1>
+		<p>
+			<strong>gnocal</strong> connects user-generated events on <code>gno.land</code> to the calendars people already use — like Google Calendar, Apple Calendar, or any app that supports the <code>.ics</code> format.
+		</p>
+
+		<p>
+			It works like this: a gno.land realm defines a function called <code>RenderCal</code> with type signature <code>func RenderCal(path string) string</code>, which returns a calendar in the valid <code>.ics</code> format. gnocal will use its <em>gnoweb rpc client</em> to <code>QEval</code> the gno.land blockchain. Then, the <em>gnocal server</em> gives this back to you as a response of <code>[]byte</code>, so others can <em>subscribe</em> to the calendar using that link or download the response directly as an <code>.ics</code> file.
+		</p>
+
+		<p>
+			To use gnocal, just visit a URL like:
+		</p>
+
+		<pre><code>https://gnocal.aiblabs.net/gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar?format=ics</code></pre>
+
+		<p>
+			Then copy that link into your calendar app as a subscription. Your users will automatically see updates to your realm's events, right in their calendar.
+		</p>
+
+		<p>
+			As you try to build a path on <code>https://gnocal.aiblabs.net/</code>, there will be helpful colored error messages assiting you on where you want to go. 
+		</p>
+
+		<footer>
+			<em>gnocal is a project by aiblabs — built for the decentralized web.</em>
+		</footer>
+	</div>
+</body>
+</html>

--- a/projects/gnocal/static/no_render_defined.html
+++ b/projects/gnocal/static/no_render_defined.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>gnocal :: No Render Functions</title>
+  <link rel="stylesheet" href="/static/errors.css">
+</head>
+<body>
+  <div class="box">
+    <div class="error">✘ No Render or RenderCal functions found</div>
+    <p>The realm you entered exists but does not define either:</p>
+
+    <ul>
+      <li><code>RenderCal(string)</code> — used to return calendar data</li>
+      <li><code>Render()</code> — used to display a webpage on gno.land</li>
+    </ul>
+
+    <p>This means the realm may be used for backend logic, governance, storage, or other non-visual purposes.</p>
+
+    <p class="note">
+      If you were expecting this realm to produce a calendar or webpage, double-check the realm path or contact the realm developer.
+    </p>
+
+    <p><a href="/">← Back to landing page</a></p>
+  </div>
+</body>
+</html>

--- a/projects/gnocal/static/rendercal_not_declared.html
+++ b/projects/gnocal/static/rendercal_not_declared.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>gnocal :: RenderCal Not Declared</title>
+  <link rel="stylesheet" href="/static/errors.css">
+</head>
+<body>
+  <div class="box">
+    <div class="error">✘ RenderCal not declared</div>
+    <p>The path you entered points to a valid Gno realm that implements <code>Render()</code>, but it does not define a <code>RenderCal()</code> function.</p>
+
+    <p>You can still view the regular web output from this realm here:</p>
+
+    <p>
+      <a href="https://{{.RealmPath}}" target="_blank" class="value">{{.RealmPath}}</a>
+    </p>
+
+    <p class="note">
+      If you're the developer, consider adding a <code>RenderCal(string)</code> function to support calendar views.
+    </p>
+
+    <p><a href="/">← Back to landing page</a></p>
+  </div>
+</body>
+</html>

--- a/projects/gnocal/static/unknown_render_error.html
+++ b/projects/gnocal/static/unknown_render_error.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>gnocal :: Unknown Error</title>
+  <link rel="stylesheet" href="/static/errors.css">
+</head>
+<body>
+  <div class="box">
+    <div class="error">⚠ Unknown Error During Render</div>
+    <p>We encountered an unexpected error when trying to render this realm. This might be a new edge case or an unhandled issue in <code>gnocal</code>.</p>
+
+    <p>Please help us improve by reporting it on GitHub:</p>
+
+    <ul>
+      <li><a href="https://github.com/allinbits/labs/issues" target="_blank">Open a GitHub Issue →</a></li>
+    </ul>
+
+    <p>Include the following information:</p>
+    <div class="comparison">
+      <div class="column">
+        <h3>Your Input</h3>
+        <div class="example"><code>{{.InputPath}}</code></div>
+      </div>
+      <div class="column">
+        <h3>Error Message</h3>
+        <div class="example"><code>{{.ErrorMessage}}</code></div>
+      </div>
+    </div>
+
+    <p class="note">Tip: Take a screenshot of this page and upload it to the issue. It helps us triage faster.</p>
+
+    <p><a href="/">← Back to landing page</a></p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Addresses [user experience bullet 2](https://github.com/orgs/allinbits/projects/4/views/1?pane=issue&itemId=118241859&issue=allinbits%7Clabs%7C38), "Design friendly error messages" 

## ✨ Added Static HTML Error Pages for `gnocal` Error Handling

Each file below improves user feedback when something goes wrong with realm rendering.

---

### 🔌 `connection_refused.html`
- **Handles:** Gno RPC server not running or unreachable (`connect: connection refused`)
- **Purpose:** Informs the user that the RPC server is down or incorrect.  
  Recommends checking whether `gnoland` is running and if the provided RPC URL is reachable.

---

### 📛 `invalid_realm_path.html`
- **Handles:** Realm path is not structured properly (`invalid package path`)
- **Purpose:** Displays a side-by-side comparison between the user’s input and the expected format  
  (e.g., `gno.land/r/your_realm/module`).  
  Explains the structural requirements of a valid realm path.

---

### 📄 `rendercal_not_declared.html`
- **Handles:** `RenderCal()` function is missing, but `Render()` is present
- **Purpose:** Lets the user know the realm can display a web page but does not produce a calendar.  
  Provides a direct clickable link to view the realm on `gno.land`.

---

### 🚫 `no_render_functions.html`
- **Handles:** Neither `Render()` nor `RenderCal()` is present
- **Purpose:** Explains that the realm may exist for backend, governance, or storage purposes.  
  Encourages users to verify the realm or contact its developer.

---

### 🐛 `unknown_render_error.html`
- **Handles:** Any unclassified or unexpected error from `QEval`
- **Purpose:** Alerts the user that this is a new or unhandled error in `gnocal`.  
  Encourages reporting the issue on GitHub with their input and error string.  
  Suggests uploading a screenshot for easier triaging.

---
