### PR TITLE
feat: add tx-indexer

### DIFF
--- a/projects/gnoland/caddy/fly.toml
+++ b/projects/gnoland/caddy/fly.toml
@@ -30,4 +30,4 @@ handlers = ["tls"]
 
 [[vm]]
 memory = '256mb'
-siz = 'shared-cpu-1x'
+size = 'shared-cpu-1x'

--- a/projects/gnoland/fly.toml
+++ b/projects/gnoland/fly.toml
@@ -16,6 +16,5 @@ GNOROOT = '/gnoroot'
 app = "staging"
 
 [[vm]]
+size = 'performance-2x'
 memory = '4gb'
-cpu_kind = 'shared'
-cpus = 2

--- a/projects/gnoland/tx-indexer/Dockerfile
+++ b/projects/gnoland/tx-indexer/Dockerfile
@@ -1,2 +1,9 @@
-FROM ghcr.io/gnolang/tx-indexer:0.5.4
+FROM ghcr.io/gnolang/tx-indexer:0.5.4 AS tx-indexer
 
+FROM cgr.dev/chainguard/static:latest
+
+WORKDIR /var/lib/app
+
+COPY --from=tx-indexer /tx-indexer /tx-indexer
+
+ENTRYPOINT [ "/tx-indexer" ]

--- a/projects/gnoland/tx-indexer/fly.toml
+++ b/projects/gnoland/tx-indexer/fly.toml
@@ -1,0 +1,22 @@
+# fly.toml app configuration file generated for labsnet-txindexer-3342 on 2025-07-16T15:21:46-06:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'labsnet-txindexer-3342'
+primary_region = 'dfw'
+
+[build]
+
+[processes]
+app = 'start -remote http://labsnet.internal:26657'
+
+[http_service]
+internal_port = 8546
+force_https = true
+auto_stop_machines = 'off'
+min_machines_running = 1
+processes = ['app']
+
+[[vm]]
+size = 'performance-1x'

--- a/projects/gnoland/tx-indexer/fly.toml
+++ b/projects/gnoland/tx-indexer/fly.toml
@@ -16,6 +16,7 @@ internal_port = 8546
 force_https = true
 auto_stop_machines = 'off'
 min_machines_running = 1
+max_machines_running = 1
 processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
This is the full config for the new indexer server. It is pretty straightforward.

The only reason I'm building a container is that I found a bug in the current container that doesn't work with TLS, so I have an open PR for that. https://github.com/gnolang/tx-indexer/pull/179

Once we have that in place, I'll update this so that we don't have to build our base image. Pretty simple and straightforward though!