### PR TITLE
feat: updating UI and adding new data structure for guild lookup

### DIFF
--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -37,15 +37,6 @@ jobs:
           filters: |
             gno-land:
               - 'projects/gnoland/gno.land/**'
-      - name: Run format check
-        run: |
-          cd projects/gnoland
-          make fmt
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "Error: 'make fmt' modified files. Please run 'make fmt' locally and commit the changes."
-            git diff
-            exit 1
-          fi
 
       - name: Run tests for ${{ matrix.test-path }}
         run: |

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -14,6 +14,44 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-path:
+          - gno.land/r/linker000/discord/role/v0
+          - gno.land/r/linker000/discord/user/v0
+          - gno.land/r/linker000/discord/keyring/v0
+          # - gno.land/r/buidlthefuture000/events/gnolandlaunch
+          # - gno.land/r/buidlthefuture000/events/gnoplan001
+          # - gno.land/r/buidlthefuture000/events/onsite001
+          # - gno.land/r/frames000
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for Caddy changes
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            gno-land:
+              - 'projects/gnoland/gno.land/**'
+      - name: Run format check
+        run: |
+          cd projects/gnoland
+          make fmt
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Error: 'make fmt' modified files. Please run 'make fmt' locally and commit the changes."
+            git diff
+            exit 1
+          fi
+
+      - name: Run tests for ${{ matrix.test-path }}
+        run: |
+          cd projects/gnoland
+          make test path=${{ matrix.test-path }}
+
   deploy-caddy:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/projects/gnoland/Makefile
+++ b/projects/gnoland/Makefile
@@ -18,6 +18,9 @@ dev: down build
 staging: down build
 	docker compose run --rm gnodev-labs staging
 
+fmt:
+	gno fmt ./... -w
+
 # Pass test path to docker using testrunner
 test: build-test
 	@if [ -z "$(path)" ]; then \

--- a/projects/gnoland/Makefile
+++ b/projects/gnoland/Makefile
@@ -28,3 +28,14 @@ test: build-test
 	else \
 		docker run --rm gnoland-testrunner gno test -v /gnoroot/examples/$(path); \
 	fi
+
+deploy-labsnet:
+	@echo "Deploying labsnet to fly.io..."
+	fly deploy --remote-only
+
+deploy-indexer:
+	@echo "Deploying indexer to fly.io..."
+	@cd tx-indexer && fly deploy --remote-only
+
+deploy-all: deploy-labsnet deploy-indexer
+	@echo "All deployments completed."

--- a/projects/gnoland/gno.land/r/linker000/discord/role/v0/datastore.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/role/v0/datastore.gno
@@ -6,7 +6,7 @@ import (
 	"gno.land/p/demo/avl"
 )
 
-// datastore keeps a *Claim database indexed by key/value store optimized for 3 types of queries
+// datastore keeps a *Claim database indexed by key/value store optimized for 4 types of queries
 // byPathRoleGuild is keyed by realmPath|roleName|guildID, if you know these 3 pieces of information
 // you can quickly find the discordRoleID linked to this realm and discord server
 // byGuildRole is keyed by discordGuildID|discordRoleID, if you know the discord server and role information
@@ -14,10 +14,13 @@ import (
 // byGuildRealm is a nested AVL tree keyed by RealmPath and Guild, contains a nested AVL tree that
 // keeps track of all registered roles for that realm and discord server combination, making it easier
 // to perform membership lookups
+// byGuild is a nested AVL tree keyed by guildID, contains a nested AVL tree that
+// keeps track of all claims for that guild, making it easy to get all realm roles for a guild
 type datastore struct {
 	byPathRoleGuild *avl.Tree
 	byGuildRole     *avl.Tree
 	byPathGuild     *avl.Tree
+	byGuild         *avl.Tree
 }
 
 func newDatastore() *datastore {
@@ -25,6 +28,7 @@ func newDatastore() *datastore {
 		byPathRoleGuild: avl.NewTree(),
 		byGuildRole:     avl.NewTree(),
 		byPathGuild:     avl.NewTree(),
+		byGuild:         avl.NewTree(),
 	}
 }
 
@@ -41,6 +45,7 @@ func (ds *datastore) set(claim *Claim) error {
 	ds.byPathRoleGuild.Set(claim.PathRoleGuildKey(), claim)
 	ds.byGuildRole.Set(claim.GuildRoleKey(), claim)
 	ds.addRoleToPathGuild(claim.roleName, claim.realmPath, claim.discordGuildID)
+	ds.addClaimToGuild(claim)
 	return nil
 }
 
@@ -51,6 +56,7 @@ func (ds *datastore) removeByPathRoleGuild(realmPath, roleName, guildID string) 
 		claim := value.(*Claim)
 		ds.removeByGuildRole(claim.discordGuildID, claim.discordRoleID)
 		ds.removeRoleFromPathGuild(claim.roleName, claim.realmPath, claim.discordGuildID)
+		ds.removeClaimFromGuild(claim)
 	}
 }
 
@@ -62,6 +68,7 @@ func (ds *datastore) removeByGuildRole(guildID, roleID string) {
 		key := fmtPathRoleGuildKey(claim.realmPath, claim.roleName, claim.discordGuildID)
 		ds.byPathRoleGuild.Remove(key)
 		ds.removeRoleFromPathGuild(claim.roleName, claim.realmPath, claim.discordGuildID)
+		ds.removeClaimFromGuild(claim)
 	}
 }
 
@@ -114,6 +121,42 @@ func (ds *datastore) listRolesByPathGuild(realmPath, guildID string) []string {
 	results := []string{}
 	roles.Iterate("", "", func(key string, _ any) bool {
 		results = append(results, key)
+		return false
+	})
+	return results
+}
+
+func (ds *datastore) addClaimToGuild(claim *Claim) {
+	value, ok := ds.byGuild.Get(claim.discordGuildID)
+	if !ok {
+		ds.byGuild.Set(claim.discordGuildID, avl.NewTree())
+		value, _ = ds.byGuild.Get(claim.discordGuildID)
+	}
+	claims := value.(*avl.Tree)
+	// Use a unique key combining path, role, and guild for the nested tree
+	claimKey := claim.PathRoleGuildKey()
+	claims.Set(claimKey, claim)
+}
+
+func (ds *datastore) removeClaimFromGuild(claim *Claim) {
+	value, ok := ds.byGuild.Get(claim.discordGuildID)
+	if !ok {
+		return
+	}
+	claims := value.(*avl.Tree)
+	claimKey := claim.PathRoleGuildKey()
+	claims.Remove(claimKey)
+}
+
+func (ds *datastore) listClaimsByGuild(guildID string) []*Claim {
+	value, ok := ds.byGuild.Get(guildID)
+	if !ok {
+		return []*Claim{}
+	}
+	claims := value.(*avl.Tree)
+	results := []*Claim{}
+	claims.Iterate("", "", func(_ string, value any) bool {
+		results = append(results, value.(*Claim))
 		return false
 	})
 	return results

--- a/projects/gnoland/gno.land/r/linker000/discord/role/v0/datastore_test.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/role/v0/datastore_test.gno
@@ -23,6 +23,9 @@ func TestNewDatastore(t *testing.T) {
 	if ds.byPathGuild == nil {
 		t.Errorf("byPathGuild should be initialized")
 	}
+	if ds.byGuild == nil {
+		t.Errorf("byGuild should be initialized")
+	}
 }
 
 // TestDatastoreSet tests the set method with various scenarios
@@ -497,5 +500,132 @@ func TestDatastoreComplexScenario(t *testing.T) {
 	}
 	if ds.getByGuildRole("guild456", "role_user") == nil {
 		t.Errorf("user should still exist")
+	}
+}
+
+// TestDatastoreByGuild tests the new byGuild index functionality
+func TestDatastoreByGuild(t *testing.T) {
+	ds := newDatastore()
+	alice := testutils.TestAddress("alice")
+	bob := testutils.TestAddress("bob")
+	charlie := testutils.TestAddress("charlie")
+
+	// Test 1: Non-existent guild should return empty slice
+	result := ds.listClaimsByGuild("guild456")
+	if len(result) != 0 {
+		t.Errorf("non-existent guild should return empty slice, got: %v", result)
+	}
+
+	// Test 2: Add multiple claims for same guild but different realms/roles
+	claim1 := &Claim{
+		timestamp:        time.Now(),
+		discordAccountID: "user123",
+		discordGuildID:   "guild456",
+		discordRoleID:    "role_admin",
+		addr:             alice,
+		roleName:         "admin",
+		realmPath:        "gno.land/r/demo/app1",
+	}
+	claim2 := &Claim{
+		timestamp:        time.Now(),
+		discordAccountID: "user456",
+		discordGuildID:   "guild456", // same guild
+		discordRoleID:    "role_mod",
+		addr:             bob,
+		roleName:         "moderator",
+		realmPath:        "gno.land/r/demo/app2", // different realm
+	}
+	claim3 := &Claim{
+		timestamp:        time.Now(),
+		discordAccountID: "user789",
+		discordGuildID:   "guild456", // same guild
+		discordRoleID:    "role_user",
+		addr:             charlie,
+		roleName:         "user",
+		realmPath:        "gno.land/r/demo/app1", // same realm as claim1
+	}
+	claim4 := &Claim{
+		timestamp:        time.Now(),
+		discordAccountID: "user999",
+		discordGuildID:   "guild789", // different guild
+		discordRoleID:    "role_admin2",
+		addr:             alice,
+		roleName:         "admin",
+		realmPath:        "gno.land/r/demo/app3",
+	}
+
+	// Add all claims
+	if err := ds.set(claim1); err != nil {
+		t.Errorf("adding claim1 should succeed: %v", err)
+	}
+	if err := ds.set(claim2); err != nil {
+		t.Errorf("adding claim2 should succeed: %v", err)
+	}
+	if err := ds.set(claim3); err != nil {
+		t.Errorf("adding claim3 should succeed: %v", err)
+	}
+	if err := ds.set(claim4); err != nil {
+		t.Errorf("adding claim4 should succeed: %v", err)
+	}
+
+	// Test 3: List all claims for guild456
+	result = ds.listClaimsByGuild("guild456")
+	if len(result) != 3 {
+		t.Errorf("expected 3 claims for guild456, got: %v", len(result))
+	}
+
+	// Verify all claims are present
+	foundClaims := make(map[string]bool)
+	for _, claim := range result {
+		key := claim.realmPath + "|" + claim.roleName
+		foundClaims[key] = true
+	}
+	if !foundClaims["gno.land/r/demo/app1|admin"] {
+		t.Errorf("should find app1 admin claim")
+	}
+	if !foundClaims["gno.land/r/demo/app2|moderator"] {
+		t.Errorf("should find app2 moderator claim")
+	}
+	if !foundClaims["gno.land/r/demo/app1|user"] {
+		t.Errorf("should find app1 user claim")
+	}
+
+	// Test 4: List claims for guild789
+	result = ds.listClaimsByGuild("guild789")
+	if len(result) != 1 {
+		t.Errorf("expected 1 claim for guild789, got: %v", len(result))
+	}
+	if result[0].realmPath != "gno.land/r/demo/app3" || result[0].roleName != "admin" {
+		t.Errorf("unexpected claim for guild789: %v", result[0])
+	}
+
+	// Test 5: Remove a claim and verify byGuild is updated
+	ds.removeByPathRoleGuild("gno.land/r/demo/app1", "admin", "guild456")
+	
+	result = ds.listClaimsByGuild("guild456")
+	if len(result) != 2 {
+		t.Errorf("expected 2 claims for guild456 after removal, got: %v", len(result))
+	}
+
+	// Verify the removed claim is not in the list
+	foundRemoved := false
+	for _, claim := range result {
+		if claim.realmPath == "gno.land/r/demo/app1" && claim.roleName == "admin" {
+			foundRemoved = true
+		}
+	}
+	if foundRemoved {
+		t.Errorf("removed claim should not be in the list")
+	}
+
+	// Test 6: Remove by guild-role and verify byGuild is updated
+	ds.removeByGuildRole("guild456", "role_mod")
+
+	result = ds.listClaimsByGuild("guild456")
+	if len(result) != 1 {
+		t.Errorf("expected 1 claim for guild456 after second removal, got: %v", len(result))
+	}
+	if result[0].realmPath != "gno.land/r/demo/app1" || result[0].roleName != "user" {
+		t.Errorf("unexpected remaining claim: %v", result[0])
 	}
 }

--- a/projects/gnoland/gno.land/r/linker000/discord/role/v0/datastore_test.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/role/v0/datastore_test.gno
@@ -601,7 +601,7 @@ func TestDatastoreByGuild(t *testing.T) {
 
 	// Test 5: Remove a claim and verify byGuild is updated
 	ds.removeByPathRoleGuild("gno.land/r/demo/app1", "admin", "guild456")
-	
+
 	result = ds.listClaimsByGuild("guild456")
 	if len(result) != 2 {
 		t.Errorf("expected 2 claims for guild456 after removal, got: %v", len(result))

--- a/projects/gnoland/gno.land/r/linker000/discord/role/v0/render.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/role/v0/render.gno
@@ -80,6 +80,7 @@ func renderClaim(w *mux.ResponseWriter, r *mux.Request) {
 
 	w.Write("# Role Claim Manager\n")
 	w.Write("View your Claim details from the discord linker bot. Sign the transaction with the magic link to link these roles to your server.\n")
+	w.Write("You **must** sign the transaction with the magic link to link these roles to your server.\n")
 
 	claim, err := validateEncodedClaim(encodedClaim, true)
 	if err != nil {
@@ -89,9 +90,16 @@ func renderClaim(w *mux.ResponseWriter, r *mux.Request) {
 	}
 
 	w.Write(ufmt.Sprintf(`
-## Easy Actions:
+## Magic Link to Link your Discord Guild Role to this Realm.
 
-- [Claim Linked Discord Role](%v)
+Use the link below to link your Discord role to your Realm. This will create a transaction that links the role to your Realm.
+
+[Claim Linked Discord Role](%v)
+
+## Other Actions:
+
+Use this link to unlink the role from your Realm, or to confirm the link is connected to your Realm.
+
 - [Remove Linked Discord Role](%v)
 - [Confirm link](/r/linker000/discord/role/v0:link/d/%v/%v)
 

--- a/projects/gnoland/gno.land/r/linker000/discord/role/v0/role.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/role/v0/role.gno
@@ -106,3 +106,19 @@ func ListLinkedRoles(realmPath, guildID string) []LinkedRealmRole {
 func ListLinkedRolesJSON(realmPath, guildID string) string {
 	return linkedRealmRolesToJSON(ListLinkedRoles(realmPath, guildID))
 }
+
+// ListAllRolesByGuild takes a discord guildID and returns all LinkedRealmRoles
+// for that guild, regardless of realm path.
+func ListAllRolesByGuild(guildID string) []LinkedRealmRole {
+	results := []LinkedRealmRole{}
+	claims := ds.listClaimsByGuild(guildID)
+	for _, claim := range claims {
+		results = append(results, claim.RealmRoleDetails())
+	}
+	return results
+}
+
+// ListAllRolesByGuildJSON returns a json encoded string for ListAllRolesByGuild.
+func ListAllRolesByGuildJSON(guildID string) string {
+	return linkedRealmRolesToJSON(ListAllRolesByGuild(guildID))
+}

--- a/projects/gnoland/gno.land/r/linker000/discord/role/v0/role_test.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/role/v0/role_test.gno
@@ -408,3 +408,205 @@ func TestRoleDatastoreRemovalConsistency(t *testing.T) {
 }
 
 // Note: Helper functions containsString and indexOfString are defined in claim_test.gno
+
+func TestListAllRolesByGuild(t *testing.T) {
+	// Reset datastore for test isolation
+	ds = newDatastore()
+
+	alice := testutils.TestAddress("alice")
+	bob := testutils.TestAddress("bob")
+	charlie := testutils.TestAddress("charlie")
+
+	// Test 1: Non-existent guild should return empty list
+	result := ListAllRolesByGuild("987654321098765432")
+	if len(result) != 0 {
+		t.Errorf("non-existent guild should return empty list, got: %v", result)
+	}
+
+	// Test 2: Add roles from different realms for same guild
+	claim1 := &Claim{
+		discordAccountID: "123456789012345678",
+		discordGuildID:   "987654321098765432",
+		discordRoleID:    "111222333444555666",
+		addr:             alice,
+		roleName:         "admin",
+		realmPath:        "gno.land/r/demo/app1",
+	}
+	claim2 := &Claim{
+		discordAccountID: "555666777888999000",
+		discordGuildID:   "987654321098765432", // same guild
+		discordRoleID:    "777888999000111222",
+		addr:             bob,
+		roleName:         "moderator",
+		realmPath:        "gno.land/r/demo/app2", // different realm
+	}
+	claim3 := &Claim{
+		discordAccountID: "999888777666555444",
+		discordGuildID:   "987654321098765432", // same guild
+		discordRoleID:    "333222111000999888",
+		addr:             charlie,
+		roleName:         "user",
+		realmPath:        "gno.land/r/demo/app1", // same realm as claim1
+	}
+	claim4 := &Claim{
+		discordAccountID: "111222333444555666",
+		discordGuildID:   "111111111111111111", // different guild
+		discordRoleID:    "222222222222222222",
+		addr:             alice,
+		roleName:         "admin",
+		realmPath:        "gno.land/r/demo/app3",
+	}
+
+	// Add all claims
+	ds.set(claim1)
+	ds.set(claim2)
+	ds.set(claim3)
+	ds.set(claim4)
+
+	// Test 3: List all roles for guild 987654321098765432
+	result = ListAllRolesByGuild("987654321098765432")
+	if len(result) != 3 {
+		t.Errorf("expected 3 roles for guild 987654321098765432, got: %v", len(result))
+	}
+
+	// Verify all expected roles are present
+	foundRoles := make(map[string]bool)
+	for _, role := range result {
+		key := role.RealmPath + "|" + role.RealmRoleName
+		foundRoles[key] = true
+	}
+	if !foundRoles["gno.land/r/demo/app1|admin"] {
+		t.Errorf("should find app1 admin role")
+	}
+	if !foundRoles["gno.land/r/demo/app2|moderator"] {
+		t.Errorf("should find app2 moderator role")
+	}
+	if !foundRoles["gno.land/r/demo/app1|user"] {
+		t.Errorf("should find app1 user role")
+	}
+
+	// Test 4: List roles for guild 111111111111111111
+	result = ListAllRolesByGuild("111111111111111111")
+	if len(result) != 1 {
+		t.Errorf("expected 1 role for guild 111111111111111111, got: %v", len(result))
+	}
+	if result[0].RealmPath != "gno.land/r/demo/app3" || result[0].RealmRoleName != "admin" {
+		t.Errorf("unexpected role for guild 111111111111111111: %+v", result[0])
+	}
+
+	// Test 5: Empty guild ID should return empty list
+	result = ListAllRolesByGuild("")
+	if len(result) != 0 {
+		t.Errorf("empty guild ID should return empty list, got: %v", result)
+	}
+}
+
+func TestListAllRolesByGuildJSON(t *testing.T) {
+	// Reset datastore for test isolation
+	ds = newDatastore()
+
+	alice := testutils.TestAddress("alice")
+	bob := testutils.TestAddress("bob")
+
+	// Test 1: Empty guild should return empty JSON array
+	result := ListAllRolesByGuildJSON("987654321098765432")
+	if result != "[]" {
+		t.Errorf("empty guild should return '[]', got '%v'", result)
+	}
+
+	// Test 2: Add roles and verify JSON
+	claim1 := &Claim{
+		discordAccountID: "123456789012345678",
+		discordGuildID:   "987654321098765432",
+		discordRoleID:    "111222333444555666",
+		addr:             alice,
+		roleName:         "admin",
+		realmPath:        "gno.land/r/demo/app1",
+	}
+	claim2 := &Claim{
+		discordAccountID: "555666777888999000",
+		discordGuildID:   "987654321098765432",
+		discordRoleID:    "777888999000111222",
+		addr:             bob,
+		roleName:         "moderator",
+		realmPath:        "gno.land/r/demo/app2",
+	}
+	ds.set(claim1)
+	ds.set(claim2)
+
+	result = ListAllRolesByGuildJSON("987654321098765432")
+
+	// Should be a valid JSON array
+	if result[0] != '[' || result[len(result)-1] != ']' {
+		t.Errorf("result should be wrapped in square brackets, got: %v", result)
+	}
+
+	// Should contain both roles
+	if !containsString(result, "admin") {
+		t.Errorf("should contain admin role in JSON")
+	}
+	if !containsString(result, "moderator") {
+		t.Errorf("should contain moderator role in JSON")
+	}
+	if !containsString(result, "gno.land/r/demo/app1") {
+		t.Errorf("should contain app1 realm path in JSON")
+	}
+	if !containsString(result, "gno.land/r/demo/app2") {
+		t.Errorf("should contain app2 realm path in JSON")
+	}
+}
+
+func TestListAllRolesByGuildAfterRemoval(t *testing.T) {
+	// Reset datastore for test isolation
+	ds = newDatastore()
+
+	alice := testutils.TestAddress("alice")
+	bob := testutils.TestAddress("bob")
+
+	// Setup: Add roles
+	claim1 := &Claim{
+		discordAccountID: "123456789012345678",
+		discordGuildID:   "987654321098765432",
+		discordRoleID:    "111222333444555666",
+		addr:             alice,
+		roleName:         "admin",
+		realmPath:        "gno.land/r/demo/app1",
+	}
+	claim2 := &Claim{
+		discordAccountID: "555666777888999000",
+		discordGuildID:   "987654321098765432",
+		discordRoleID:    "777888999000111222",
+		addr:             bob,
+		roleName:         "moderator",
+		realmPath:        "gno.land/r/demo/app2",
+	}
+	ds.set(claim1)
+	ds.set(claim2)
+
+	// Verify initial state
+	result := ListAllRolesByGuild("987654321098765432")
+	if len(result) != 2 {
+		t.Errorf("expected 2 roles initially, got: %v", len(result))
+	}
+
+	// Remove admin role
+	ds.removeByPathRoleGuild("gno.land/r/demo/app1", "admin", "987654321098765432")
+
+	// Verify list is updated
+	result = ListAllRolesByGuild("987654321098765432")
+	if len(result) != 1 {
+		t.Errorf("expected 1 role after removal, got: %v", len(result))
+	}
+	if result[0].RealmPath != "gno.land/r/demo/app2" || result[0].RealmRoleName != "moderator" {
+		t.Errorf("remaining role should be app2 moderator, got: %+v", result[0])
+	}
+
+	// Remove moderator role
+	ds.removeByGuildRole("987654321098765432", "777888999000111222")
+
+	// Verify list is empty
+	result = ListAllRolesByGuild("987654321098765432")
+	if len(result) != 0 {
+		t.Errorf("expected empty list after removing all roles, got: %v", len(result))
+	}
+}

--- a/projects/gnoland/gno.land/r/linker000/discord/user/v0/render.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/user/v0/render.gno
@@ -28,8 +28,12 @@ func Render(path string) string {
 
 func renderHome(w *mux.ResponseWriter, r *mux.Request) {
 	w.Write("# DiscordLinker Home\n\n")
-	w.Write("Welcome. This smart contract is used to link your Discord ID to your gno address.\n\n")
-	w.Write("To get started, go to the discord bot on the gno.land discord server and type `!help` for additional information.\n")
+	w.Write("Welcome. This realm is used to link your Discord ID to your gno address.\n\n")
+
+	w.Write("You can link your Discord ID to your gno address by adding `:link/d/{id}` to this URL. or\n\n")
+	w.Write("You can link your gno address to your Discord ID by using adding `:link/g/{addr}` to this URL.\n\n")
+
+	w.Write("To get started, go to the discord bot on the gno.land discord server and type `/gnolinker help` for additional information.\n")
 }
 
 func renderLinkByDiscordID(w *mux.ResponseWriter, r *mux.Request) {
@@ -73,14 +77,36 @@ func renderClaim(w *mux.ResponseWriter, r *mux.Request) {
 	}
 
 	w.Write(ufmt.Sprintf(`
-## Easy Actions:
+## Easy Action:
 
-- [Claim Linked Accounts](%v)
-- [Remove Link by Claim](%v)
+[Claim Linked Accounts](%v)
+
+## What you are linking
+
+This will link your Discord ID to your Gno address, allowing you to use your Discord ID to interact with Gno applications.
+
+### discordID
+
+%v
+
+### Gno Address
+
+%v
+
+`, txlink.NewLink("Link").AddArgs("encodedClaim", encodedClaim).URL(), 
+claim.discordID, 
+string(claim.addr)))
+
+	w.Write(ufmt.Sprintf(`
+## Other Actions:
+
+- [Remove Linked Account by Gno Address](%v) - Use this to unlink from your discord ID only using your gno address.
+- [Remove Link by Claim](%v) - Use this to unlink from your discord ID, even if you've lost access to your old gno address.
 - [Confirm link](/r/linker000/discord/user/v0:link/g/%v)
 
 `,
-		txlink.NewLink("Link").AddArgs("encodedClaim", encodedClaim).URL(),
+		
+		txlink.NewLink("Unlink").AddArgs("encodedClaim", encodedClaim).URL(),
 		txlink.NewLink("UnlinkByClaim").AddArgs("encodedClaim", encodedClaim).URL(),
 		string(claim.addr),
 	))

--- a/projects/gnoland/gno.land/r/linker000/discord/user/v0/render.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/user/v0/render.gno
@@ -93,9 +93,9 @@ This will link your Discord ID to your Gno address, allowing you to use your Dis
 
 %v
 
-`, txlink.NewLink("Link").AddArgs("encodedClaim", encodedClaim).URL(), 
-claim.discordID, 
-string(claim.addr)))
+`, txlink.NewLink("Link").AddArgs("encodedClaim", encodedClaim).URL(),
+		claim.discordID,
+		string(claim.addr)))
 
 	w.Write(ufmt.Sprintf(`
 ## Other Actions:
@@ -105,7 +105,7 @@ string(claim.addr)))
 - [Confirm link](/r/linker000/discord/user/v0:link/g/%v)
 
 `,
-		
+
 		txlink.NewLink("Unlink").AddArgs("encodedClaim", encodedClaim).URL(),
 		txlink.NewLink("UnlinkByClaim").AddArgs("encodedClaim", encodedClaim).URL(),
 		string(claim.addr),


### PR DESCRIPTION
This PR includes  1 update to functionality and 2 updates to UX to make it easier to grab a claim.

- ADDED `byGuild` data structure, which makes it easier for the gnolinker bot to find _all realms and roles_ linked to a particular guild. This simplifies the lookup process for syncing. This does not break any current implementations; it only extends functionality

- UPDATED user UI to break out claim TX link from other actions
- UPDATED role UI to break out claim TX link from other actions
