### PR TITLE
refactor component

### DIFF
--- a/projects/gnoland/gno.land/p/eve000/event/agenda/agenda.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/agenda/agenda.gno
@@ -41,7 +41,7 @@ func (a *Agenda) ToAnchor() string {
 	return component.StringToAnchor(a.Name)
 }
 
-func (a *Agenda) ToMarkdown(_ ...component.Content) string {
+func (a *Agenda) ToMarkdown(body ...component.Content) string {
 	markdown := "## " + a.Name + "\n\n"
 
 	if _, ok := a.RenderOpts()["Location"]; ok && a.Location != nil {
@@ -58,8 +58,14 @@ func (a *Agenda) ToMarkdown(_ ...component.Content) string {
 
 	markdown += a.Description + "\n\n"
 
-	if a.Banner != nil && a.Banner.Published {
-		markdown += a.Banner.Markdown + "\n\n"
+	if len(body) > 0 {
+		for _, content := range body {
+			if content.Published {
+				markdown += content.Render() + "\n\n"
+			}
+		}
+	} else if a.Banner != nil && a.Banner.Published {
+		markdown += a.Banner.Render() + "\n\n"
 	}
 
 	markdown += "## Agenda \n\n"

--- a/projects/gnoland/gno.land/p/eve000/event/component/component.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/component.gno
@@ -55,6 +55,7 @@ func RenderComponent(path string, c Component) (out string) {
 type Content struct {
 	Published bool
 	Markdown  string
+	Callback  func(string) string
 }
 
 func (c *Content) SetPublished(published bool) {
@@ -63,6 +64,36 @@ func (c *Content) SetPublished(published bool) {
 
 func (c *Content) SetMarkdown(markdown string) {
 	c.Markdown = markdown
+}
+
+// Render displays stored content or calls the callback function if provided.
+func (c *Content) Render(p ...string) string {
+	path := ""
+	if len(p) == 1 {
+		path = p[0]
+	}
+	u, err := url.Parse(path)
+	if err != nil {
+		panic("invalid path in Content.Render: " + path)
+	}
+	format := u.Query().Get("format")
+	if format == "json" {
+		if c.Callback != nil {
+			return c.Callback(path)
+		}
+		return "{\"markdown\": \"" + escapeHtml(c.Markdown) + "\", \"published\": " + strconv.FormatBool(c.Published) + "}"
+	}
+	if c.Markdown == "" && c.Callback == nil {
+		return ""
+	}
+	if c.Published {
+		if c.Callback != nil {
+			return c.Callback(path)
+		} else {
+			return c.Markdown
+		}
+	}
+	return ""
 }
 
 func StringToAnchor(text string) string {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
@@ -1,11 +1,15 @@
-- [ ] consider refactoring component.Content to use callbacks instead of static blocks of MD
-- [ ] refactor moving calendar and proposals out of /gnolandlaunch
 - [ ] add URL pointer for aiblabs etc..  for calendar events
 - [ ] fix/test the `/events` api
 - [ ] add version number to bottom of /events api
 - [ ] Double check updatable content blocks - 'banner' for agenda
 - [ ] self-audit patch permissions for each event's realm
+- [ ] make sure HasRole and RenderCalendar are available at proper realms
+
+MASON
+-----
+- [ ] refactor moving calendar and proposals out of /gnolandlaunch
 
 DONE
 -----
+- [x] consider refactoring component.Content to use callbacks instead of static blocks of MD
 - [x] re-examine the Event 'Status' using schema.org for component.Event.ToJson()


### PR DESCRIPTION
adds a means to publish content as a callback or markdown

NOTE: each block has `component.Content{ published: bool }` field to allow for individual blocks to be enabled/disabled