### PR TITLE
refactor agenda view -> flyer

### DIFF
--- a/projects/gnoland/gno.land/p/eve000/event/README.md
+++ b/projects/gnoland/gno.land/p/eve000/event/README.md
@@ -6,9 +6,9 @@ Eve Package provides a structured, reusable set of components designed for build
 
 These components can be used independently or integrated into larger Eve applications:
 
-### Agenda
+### Flyer
 
-A featured component of Eve is the Agenda component. Once an organizer has all session dates and times finalized, they can create an agenda to share with the attendees. The agenda provides all relevant information like the Title, Description, Speaker(s), Location, & c. to the attendees. 
+A featured component of Eve is the Flyer component. Once an organizer has all session dates and times finalized, they can create an flyer to share with the attendees. The agenda provides all relevant information like the Title, Description, Speaker(s), Location, & c. to the attendees. 
 
 ### Calendar
 
@@ -39,7 +39,7 @@ Register is not a component but actually the storage for everything. Before the 
 
 ### Session
 
-Session is an important component because it is the building block of the Agenda component. Sessions have a Title, Format, Title, and Speaker(s). Once an organizer has amassed enough of these session components then can mix-and-match them into an agenda, and publish the finalized schedule (to an agenda) when ready. 
+Session is an important component because it is the building block of the Flyer component. Sessions have a Title, Format, Title, and Speaker(s). Once an organizer has amassed enough of these session components then can mix-and-match them into an agenda, and publish the finalized schedule (to an agenda) when ready. 
 
 ### Speaker
 
@@ -47,7 +47,7 @@ If your sessions are going to have speakers, you can make them components so the
 
 ## Important Note on Component File Structure
 
-In each component file (i.e., Event, Session, Speaker, Location, Agenda), the methods should be structured in the following specific order to maintain consistency and clarity:
+In each component file (i.e., Event, Session, Speaker, Location, Flyer), the methods should be structured in the following specific order to maintain consistency and clarity:
 
 1. **`ToAnchor()`** – Generates a web-compatible anchor link to easily navigate to specific components on a webpage.
 2. **`ToMarkdown()`** – Provides a Markdown-formatted representation suitable for web display or documentation.

--- a/projects/gnoland/gno.land/p/eve000/event/agenda/gnomod.toml
+++ b/projects/gnoland/gno.land/p/eve000/event/agenda/gnomod.toml
@@ -1,2 +1,0 @@
-module = "gno.land/p/eve000/events/agenda"
-gno = "0.9"

--- a/projects/gnoland/gno.land/p/eve000/event/component/component.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/component.gno
@@ -12,6 +12,7 @@ import (
 
 const DtFmt = "Mon Jan 2"
 
+// Component is an interface for event components that can be rendered in various formats.
 type Component interface {
 	ToAnchor() string
 	ToMarkdown(...Content) string
@@ -67,33 +68,18 @@ func (c *Content) SetMarkdown(markdown string) {
 }
 
 // Render displays stored content or calls the callback function if provided.
-func (c *Content) Render(p ...string) string {
-	path := ""
-	if len(p) == 1 {
-		path = p[0]
-	}
-	u, err := url.Parse(path)
-	if err != nil {
-		panic("invalid path in Content.Render: " + path)
-	}
-	format := u.Query().Get("format")
-	if format == "json" {
-		if c.Callback != nil {
-			return c.Callback(path)
-		}
-		return "{\"markdown\": \"" + escapeHtml(c.Markdown) + "\", \"published\": " + strconv.FormatBool(c.Published) + "}"
-	}
-	if c.Markdown == "" && c.Callback == nil {
+func (c *Content) Render(path ...string) string {
+	if !c.Published || c.Markdown == "" && c.Callback == nil {
 		return ""
 	}
-	if c.Published {
-		if c.Callback != nil {
-			return c.Callback(path)
+	if c.Callback != nil {
+		if len(path) > 0 {
+			return c.Callback(path[0])
 		} else {
-			return c.Markdown
+			return c.Callback("")
 		}
 	}
-	return ""
+	return c.Markdown
 }
 
 func StringToAnchor(text string) string {

--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -10,8 +10,8 @@ import (
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
-	"gno.land/p/eve000/event/agenda"
 	"gno.land/p/eve000/event/component"
+	"gno.land/p/eve000/event/flyer"
 	"gno.land/p/eve000/event/location"
 	"gno.land/p/eve000/event/session"
 	"gno.land/p/eve000/event/speaker"
@@ -168,8 +168,13 @@ func (evt *Event) GetSessions() []*session.Session {
 	return sessions
 }
 
-func (evt *Event) Agenda(heading *component.Content) *agenda.Agenda {
-	a := &agenda.Agenda{
+// RenderFlyer renders the event flyer with optional body content.
+func (evt *Event) RenderFlyer(body ...component.Content) string {
+	return evt.Flyer().ToMarkdown(body...)
+}
+
+func (evt *Event) Flyer() *flyer.Flyer {
+	f := &flyer.Flyer{
 		Name:        evt.Name,
 		Location:    evt.Location,
 		StartDate:   evt.StartDate,
@@ -178,9 +183,8 @@ func (evt *Event) Agenda(heading *component.Content) *agenda.Agenda {
 		Description: evt.Description,
 		Sessions:    evt.Sessions,
 	}
-	a.SetBanner(heading)
-	a.SetRenderOpts(evt.renderOpts)
-	return a
+	f.SetRenderOpts(evt.renderOpts)
+	return f
 }
 
 func (evt *Event) RenderCalendar(path string) string {
@@ -330,36 +334,16 @@ func (evt *Event) ToAnchor() string {
 	return component.StringToAnchor(evt.Name)
 }
 
-func (evt *Event) ToMarkdown(heading ...component.Content) string {
-	if len(heading) == 0 {
-		heading = append(heading, component.Content{Published: false})
-	}
-	return evt.Agenda(&heading[0]).ToMarkdown()
+func (evt *Event) ToMarkdown(body ...component.Content) string {
+	return evt.Flyer().ToMarkdown(body...)
 }
 
 func (evt *Event) ToSvgDataUrl() string {
-	heading := &component.Content{Published: false}
-	return evt.Agenda(heading).ToSvgDataUrl()
+	return evt.Flyer().ToSvgDataUrl()
 }
 
 func (evt *Event) ToSVG() string {
-	heading := &component.Content{Published: false}
-	return evt.Agenda(heading).ToSVG()
-}
-
-func (evt *Event) AssertValid() {
-	if evt.Name == "" {
-		panic("event name cannot be empty")
-	}
-	if evt.Location == nil {
-		panic("event location cannot be nil")
-	}
-	if evt.StartDate.IsZero() {
-		panic("event start date cannot be zero")
-	}
-	if evt.EndDate.IsZero() {
-		panic("event end date cannot be zero")
-	}
+	return evt.Flyer().ToSVG()
 }
 
 const DateFormatJsonLD = "2006-01-02T15:04:05-07:00"

--- a/projects/gnoland/gno.land/p/eve000/event/flyer/flyer.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/flyer/flyer.gno
@@ -1,4 +1,4 @@
-package agenda
+package flyer
 
 import (
 	"net/url"
@@ -11,20 +11,20 @@ import (
 	"gno.land/p/eve000/event/session"
 )
 
-type Agenda struct {
+// Flyer represents an event flyer with details such as name, location, dates, status, and sessions.
+type Flyer struct {
 	Name           string
 	Location       *location.Location
 	StartDate      time.Time
 	EndDate        time.Time
 	Status         component.EventStatus
 	AttendanceMode component.EventAttendanceMode
-	Banner         *component.Content
 	Description    string
 	Sessions       []*session.Session
 	renderOpts     map[string]interface{}
 }
 
-var _ component.Component = (*Agenda)(nil)
+var _ component.Component = (*Flyer)(nil)
 
 func FormatDate(date time.Time) string {
 	if date.IsZero() {
@@ -33,15 +33,12 @@ func FormatDate(date time.Time) string {
 	return date.Format(component.DtFmt)
 }
 
-func (a *Agenda) SetBanner(heading *component.Content) {
-	a.Banner = heading
-}
-
-func (a *Agenda) ToAnchor() string {
+func (a *Flyer) ToAnchor() string {
 	return component.StringToAnchor(a.Name)
 }
 
-func (a *Agenda) ToMarkdown(body ...component.Content) string {
+// ToMarkdown converts the Flyer to a Markdown representation (with optional additional content).
+func (a *Flyer) ToMarkdown(body ...component.Content) string {
 	markdown := "## " + a.Name + "\n\n"
 
 	if _, ok := a.RenderOpts()["Location"]; ok && a.Location != nil {
@@ -64,8 +61,6 @@ func (a *Agenda) ToMarkdown(body ...component.Content) string {
 				markdown += content.Render() + "\n\n"
 			}
 		}
-	} else if a.Banner != nil && a.Banner.Published {
-		markdown += a.Banner.Render() + "\n\n"
 	}
 
 	markdown += "## Agenda \n\n"
@@ -116,7 +111,7 @@ func (a *Agenda) ToMarkdown(body ...component.Content) string {
 	return markdown
 }
 
-func (a *Agenda) ToJson() string {
+func (a *Flyer) ToJson() string {
 	json := "{\n"
 	json += "\"Name\":\"" + a.Name + "\",\n"
 	json += "\"Location\":" + a.Location.ToJson() + ",\n"
@@ -134,14 +129,14 @@ func (a *Agenda) ToJson() string {
 	return json
 }
 
-func (a *Agenda) ToSVG() string {
+func (a *Flyer) ToSVG() string {
 	y := 40
 	fragment := a.ToSVGFragment(&y)
 	height := ufmt.Sprintf("%d", y)
 	return component.SvgHeading("600", height) + fragment + "</svg>"
 }
 
-func (a *Agenda) ToSVGFragment(y *int) string {
+func (a *Flyer) ToSVGFragment(y *int) string {
 	svg := "<rect width=\"100%\" height=\"100%\" fill=\"#eeeeee\" rx=\"15\"/>"
 	svg += component.RenderSVGLine(y, "title", "", a.Name)
 	*y += 10
@@ -170,56 +165,14 @@ func (a *Agenda) ToSVGFragment(y *int) string {
 	return svg
 }
 
-func (a *Agenda) ToSvgDataUrl() string {
+func (a *Flyer) ToSvgDataUrl() string {
 	return "data:image/svg+xml;utf8," + url.PathEscape(a.ToSVG())
 }
 
-func (a *Agenda) RenderOpts() map[string]interface{} {
+func (a *Flyer) RenderOpts() map[string]interface{} {
 	return a.renderOpts
 }
 
-func (a *Agenda) SetRenderOpts(opts map[string]interface{}) {
+func (a *Flyer) SetRenderOpts(opts map[string]interface{}) {
 	a.renderOpts = opts
-}
-
-func (a *Agenda) FilteredMarkdown(tag string) string {
-	markdown := "## " + component.TagToName(tag) + "\n\n"
-
-	// Group sessions by date
-	sessionsByDate := make(map[string][]*session.Session)
-	for _, session := range a.Sessions {
-		date := session.StartTime.Format(component.DtFmt)
-		sessionsByDate[date] = append(sessionsByDate[date], session)
-	}
-
-	// Generate markdown for each day
-	for date, sessions := range sessionsByDate {
-		markdown += "### " + date + "\n\n"
-		for _, session := range sessions {
-			markdown += session.ToMarkdown()
-		}
-	}
-
-	// Collect unique speakers and locations
-	var speakersMarkdown, locationsMarkdown string
-	speakersSet := make(map[string]bool)
-	locationsSet := make(map[string]bool)
-
-	for _, session := range a.Sessions {
-		// Collect unique speakers
-		speakerMarkdown := session.Speaker.ToMarkdown()
-		if !speakersSet[speakerMarkdown] {
-			speakersSet[speakerMarkdown] = true
-			speakersMarkdown += speakerMarkdown + "\n***\n"
-		}
-
-		// Collect unique locations
-		locationMarkdown := session.Location.ToMarkdown()
-		if !locationsSet[locationMarkdown] {
-			locationsSet[locationMarkdown] = true
-			locationsMarkdown += locationMarkdown + "\n***\n"
-		}
-	}
-
-	return markdown
 }

--- a/projects/gnoland/gno.land/p/eve000/event/flyer/flyer_test.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/flyer/flyer_test.gno
@@ -1,4 +1,4 @@
-package agenda
+package flyer
 
 import (
 	"strings"
@@ -11,8 +11,8 @@ import (
 	"gno.land/p/eve000/event/speaker"
 )
 
-func sampleAgenda() *Agenda {
-	return &Agenda{
+func sampleFlyer() *Flyer {
+	return &Flyer{
 		Name:        "UNIX Legends",
 		Location:    &location.Location{Name: "Main Theater"},
 		StartDate:   time.Date(2025, 4, 3, 0, 0, 0, 0, time.UTC),
@@ -37,16 +37,16 @@ func sampleAgenda() *Agenda {
 	}
 }
 
-func TestAgendaToAnchor(t *testing.T) {
-	a := sampleAgenda()
+func TestFlyerToAnchor(t *testing.T) {
+	a := sampleFlyer()
 	expected := "#unix-legends"
 	if anchor := a.ToAnchor(); anchor != expected {
 		t.Fatalf("ToAnchor mismatch: expected %q, got %q", expected, anchor)
 	}
 }
 
-func TestAgendaToMarkdown(t *testing.T) {
-	a := sampleAgenda()
+func TestFlyerToMarkdown(t *testing.T) {
+	a := sampleFlyer()
 	md := a.ToMarkdown()
 	if !strings.Contains(md, "## UNIX Legends") {
 		t.Fatal("Markdown output missing agenda title")
@@ -65,8 +65,8 @@ func TestAgendaToMarkdown(t *testing.T) {
 	}
 }
 
-func TestAgendaToJson(t *testing.T) {
-	a := sampleAgenda()
+func TestFlyerToJson(t *testing.T) {
+	a := sampleFlyer()
 	json := a.ToJson()
 	if !strings.Contains(json, `"Name":"UNIX Legends"`) {
 		t.Fatal("JSON missing agenda name")
@@ -79,8 +79,8 @@ func TestAgendaToJson(t *testing.T) {
 	}
 }
 
-func TestAgendaToSVG(t *testing.T) {
-	a := sampleAgenda()
+func TestFlyerToSVG(t *testing.T) {
+	a := sampleFlyer()
 	svg := a.ToSVG()
 	if !strings.Contains(svg, `<svg`) || !strings.Contains(svg, `UNIX Legends`) {
 		t.Fatal("SVG output missing structure or title")
@@ -90,16 +90,16 @@ func TestAgendaToSVG(t *testing.T) {
 	}
 }
 
-func TestAgendaToSvgDataUrl(t *testing.T) {
-	a := sampleAgenda()
+func TestFlyerToSvgDataUrl(t *testing.T) {
+	a := sampleFlyer()
 	dataUrl := a.ToSvgDataUrl()
 	if !strings.HasPrefix(dataUrl, "data:image/svg+xml;utf8,") {
 		t.Fatalf("SVG data URL missing prefix: %s", dataUrl[:60])
 	}
 }
 
-func TestAgendaRenderIncludesSVG(t *testing.T) {
-	a := sampleAgenda()
+func TestFlyerRenderIncludesSVG(t *testing.T) {
+	a := sampleFlyer()
 	render := a.Render()
 	if !strings.Contains(render, "data:image/svg+xml;utf8,") {
 		t.Fatal("Render output missing SVG data URL")

--- a/projects/gnoland/gno.land/p/eve000/event/flyer/gnomod.toml
+++ b/projects/gnoland/gno.land/p/eve000/event/flyer/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/eve000/events/flyer"
+gno = "0.9"

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
@@ -75,7 +75,7 @@ func (*App) Render(path string) (out string) {
 	case hasQueryParam(q, "speaker"):
 		return component.RenderComponent(path, event.GetSpeaker(q.Get("speaker")))
 	default:
-		return component.RenderComponent(path, event.Agenda(banner))
+		return event.RenderFlyer(banner)
 	}
 }
 
@@ -107,9 +107,6 @@ func (*App) Unpublish(key string) {
 func (*App) SetContent(key, markdown string) {
 	assertAccess()
 	switch key {
-	case "map":
-		eventMap.SetPublished(true)
-		eventMap.SetMarkdown(markdown)
 	case "published":
 		staticContent.SetPublished(true)
 		staticContent.SetMarkdown(markdown)
@@ -145,83 +142,63 @@ func (*App) AdminSetRole(role string, addr std.Address) {
 func (*App) AdminRemoveRole(role string, addr std.Address) {
 	acl.AdminRemoveRole(role, addr)
 }
-
 func (*App) ResetRoles() {
 	acl.ResetRoles()
 }
-
 func (*App) JoinWaitlist() {
 	acl.JoinWaitlist()
 }
-
 func (*App) RemoveSelfFromWaitlist() {
 	acl.RemoveSelfFromWaitlist()
 }
-
 func (*App) JoinAsAttendee() {
 	acl.JoinAsAttendee()
 }
-
 func (*App) RemoveSelfAsAttendee() {
 	acl.RemoveSelfAsAttendee()
 }
-
 func (*App) AddSpeaker(addr std.Address) {
 	acl.AddSpeaker(addr)
 }
-
 func (*App) RemoveSpeaker(addr std.Address) {
 	acl.RemoveSpeaker(addr)
 }
-
 func (*App) AddOrganizer(addr std.Address) {
 	acl.AddOrganizer(addr)
 }
-
 func (*App) RemoveOrganizer(addr std.Address) {
 	acl.RemoveOrganizer(addr)
 }
-
 func (*App) AddProposer(addr, sender std.Address) {
 	acl.AddProposer(addr, sender)
 }
-
 func (*App) RemoveProposer(addr, sender std.Address) {
 	acl.RemoveProposer(addr, sender)
 }
-
 func (*App) AddReviewer(addr, sender std.Address) {
 	acl.AddReviewer(addr, sender)
 }
-
 func (*App) RemoveReviewer(addr, sender std.Address) {
 	acl.RemoveReviewer(addr, sender)
 }
-
 func (*App) RoleExists(role string) bool {
 	return acl.RoleExists(role)
 }
-
 func (*App) HasRole(role string, addr std.Address) bool {
 	return acl.HasRole(role, addr)
 }
-
 func (*App) ListRoles() []string {
 	return acl.ListRoles()
 }
-
 func (*App) SetRoleHandler(role string, fn func(string) bool) {
 	acl.SetRoleHandler(role, fn)
 }
-
 func (*App) UnsetRoleHandler(role string) {
 	acl.UnsetRoleHandler(role)
 }
-
 func (*App) AssertAtLeastRole(role string, sender std.Address) {
 	acl.AssertAtLeastRole(role, sender)
 }
-
 func (*App) RenderList(role string) string {
 	return acl.RenderList(role)
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/event.gno
@@ -19,7 +19,7 @@ func init() {
 }
 
 // banner content block is shown in the top section of the event page
-var banner = &component.Content{
+var banner = component.Content{
 	Published: true,
 	Markdown: "\n\n#### Status: Accepting Session Proposals\n #### expected dates: Sept 2025 \n\n" +
 		component.TxlinkButton("Join Waitlist", "JoinWaitlist"),

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/public.gno
@@ -1,17 +1,10 @@
 package gnolandlaunch
 
-import (
-	"gno.land/p/eve000/event"
-)
-
-func LiveEvent() *event.Event {
-	return app.LiveEvent()
-}
-
+// join waitlist for event
 func JoinWaitlist() {
 	app.JoinWaitlist()
 }
 
 func RenderCalendar(path string) string {
-	return LiveEvent().RenderCalendar(path)
+	return app.LiveEvent().RenderCalendar(path)
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
@@ -75,7 +75,7 @@ func (*App) Render(path string) (out string) {
 	case hasQueryParam(q, "speaker"):
 		return component.RenderComponent(path, event.GetSpeaker(q.Get("speaker")))
 	default:
-		return component.RenderComponent(path, event.Agenda(banner))
+		return event.RenderFlyer(banner)
 	}
 }
 
@@ -107,9 +107,6 @@ func (*App) Unpublish(key string) {
 func (*App) SetContent(key, markdown string) {
 	assertAccess()
 	switch key {
-	case "map":
-		eventMap.SetPublished(true)
-		eventMap.SetMarkdown(markdown)
 	case "published":
 		staticContent.SetPublished(true)
 		staticContent.SetMarkdown(markdown)

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/event.gno
@@ -19,7 +19,7 @@ func init() {
 }
 
 // banner content block is shown in the top section of the event page
-var banner = &component.Content{
+var banner = component.Content{
 	Published: true,
 	Markdown: "\n\n#### Status: Seeking Stakeholders for Planning \n\n" +
 		component.TxlinkButton("Join Beta", "JoinBeta"),

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/public.gno
@@ -1,18 +1,10 @@
 package gnoplan
 
-import (
-	"gno.land/p/eve000/event"
-)
-
-func LiveEvent() *event.Event {
-	return app.LiveEvent()
-}
-
 // JoinBeta allows users to join the beta program for the Gno.land launch event.
 func JoinBeta() {
 	app.JoinWaitlist() // waitlist is re-used for beta program
 }
 
 func RenderCalendar(path string) string {
-	return LiveEvent().RenderCalendar(path)
+	return app.LiveEvent().RenderCalendar(path)
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
@@ -75,7 +75,7 @@ func (*App) Render(path string) (out string) {
 	case hasQueryParam(q, "speaker"):
 		return component.RenderComponent(path, event.GetSpeaker(q.Get("speaker")))
 	default:
-		return component.RenderComponent(path, event.Agenda(banner))
+		return event.RenderFlyer(banner)
 	}
 }
 
@@ -107,9 +107,6 @@ func (*App) Unpublish(key string) {
 func (*App) SetContent(key, markdown string) {
 	assertAccess()
 	switch key {
-	case "map":
-		eventMap.SetPublished(true)
-		eventMap.SetMarkdown(markdown)
 	case "published":
 		staticContent.SetPublished(true)
 		staticContent.SetMarkdown(markdown)

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
@@ -18,7 +18,7 @@ func init() {
 }
 
 // banner content block is shown in the top section of the event page
-var banner = &component.Content{
+var banner = component.Content{
 	Published: true,
 	Markdown:  "\n\n#### Status: Pre-planning",
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/public.gno
@@ -1,13 +1,5 @@
 package onsite
 
-import (
-	"gno.land/p/eve000/event"
-)
-
-func LiveEvent() *event.Event {
-	return app.LiveEvent()
-}
-
 func RenderCalendar(path string) string {
-	return LiveEvent().RenderCalendar(path)
+	return app.LiveEvent().RenderCalendar(path)
 }


### PR DESCRIPTION
- rename agenda to flyer - don't treat like a 'component' in the Render() func 

since we are injecting content blocks - it functions more like a template for a page / document / flyer