### PR TITLE
Task/refactor flyer

### DIFF
--- a/projects/gnoland/gno.land/p/eve000/event/component/component.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/component.gno
@@ -12,6 +12,34 @@ import (
 
 const DtFmt = "Mon Jan 2"
 
+// EventSchedule is an interface for event schedules that are rendered in md, json or ICS format.
+type EventSchedule interface {
+	ToJson() string
+	RenderCalendar(string) string
+	RenderMarkdown(body ...Content) string
+	Flyer() Component
+}
+
+// Event is a schema.org compatible status string
+type EventStatus string
+
+const (
+	EventScheduled   EventStatus = "https://schema.org/EventScheduled"
+	EventCancelled   EventStatus = "https://schema.org/EventCancelled"
+	EventMovedOnline EventStatus = "https://schema.org/EventMovedOnline"
+	EventPostponed   EventStatus = "https://schema.org/EventPostponed"
+	EventRescheduled EventStatus = "https://schema.org/EventRescheduled"
+)
+
+// EventAttendanceMode is a schema.org compatible attendance mode string
+type EventAttendanceMode string
+
+const (
+	OfflineEventAttendanceMode EventAttendanceMode = "https://schema.org/OfflineEventAttendanceMode"
+	OnlineEventAttendanceMode  EventAttendanceMode = "https://schema.org/OnlineEventAttendanceMode"
+	MixedEventAttendanceMode   EventAttendanceMode = "https://schema.org/MixedEventAttendanceMode"
+)
+
 // Component is an interface for event components that can be rendered in various formats.
 type Component interface {
 	ToAnchor() string
@@ -193,31 +221,6 @@ func LinkTag(name string) string {
 	return "[" + name + "](?tag=" + TagString(name) + ")"
 }
 
-func TagToName(tag string) string {
-	tag = strings.ReplaceAll(tag, "-", " ")
-	words := strings.Fields(tag)
-	for i, word := range words {
-		if len(word) > 0 {
-			words[i] = strings.ToUpper(string(word[0])) + word[1:]
-		}
-	}
-	return strings.Join(words, " ")
-}
-
-// FIXME: is this used or should it be replaced by query parameters?
-func IdFromPath(path string) int {
-	parts := strings.Split(path, ":")
-	if len(parts) < 2 {
-		panic("invalid path")
-	}
-	id, err := strconv.Atoi(parts[1])
-	if err != nil {
-		panic("invalid id")
-	}
-	return id
-}
-
-// REVIEW: consider using another library for HTML escaping if there is a better one
 func escapeHtml(s string) string {
 	s = strings.ReplaceAll(s, "&", "&amp;")
 	s = strings.ReplaceAll(s, "<", "&lt;")
@@ -258,25 +261,3 @@ func SubmitButton(label, path string, fontSize, minWidth int) string {
 
 	return "[![" + label + "](" + dataUrl + ")](" + path + ")"
 }
-
-// REVIEW: consider support for embedding the Schedule schema
-// https://schema.org/Schedule
-// https://schema.org/eventSchedule
-
-type EventStatus string
-
-const (
-	EventScheduled   EventStatus = "https://schema.org/EventScheduled"
-	EventCancelled   EventStatus = "https://schema.org/EventCancelled"
-	EventMovedOnline EventStatus = "https://schema.org/EventMovedOnline"
-	EventPostponed   EventStatus = "https://schema.org/EventPostponed"
-	EventRescheduled EventStatus = "https://schema.org/EventRescheduled"
-)
-
-type EventAttendanceMode string
-
-const (
-	OfflineEventAttendanceMode EventAttendanceMode = "https://schema.org/OfflineEventAttendanceMode"
-	OnlineEventAttendanceMode  EventAttendanceMode = "https://schema.org/OnlineEventAttendanceMode"
-	MixedEventAttendanceMode   EventAttendanceMode = "https://schema.org/MixedEventAttendanceMode"
-)

--- a/projects/gnoland/gno.land/p/eve000/event/component/component.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/component.gno
@@ -20,6 +20,11 @@ type EventSchedule interface {
 	Flyer() Component
 }
 
+type Page interface {
+	ToJson() string
+	RenderMarkdown(body ...Content) string
+}
+
 // Event is a schema.org compatible status string
 type EventStatus string
 
@@ -48,6 +53,24 @@ type Component interface {
 	ToSVG() string
 	ToSvgDataUrl() string
 	RenderOpts() map[string]interface{}
+}
+
+func RenderPage(format string, c Page, body ...Content) string {
+	if format == "json" {
+		var sb strings.Builder
+		sb.WriteString("```\n\n" + c.ToJson() + "\n\n```")
+		if len(body) > 0 {
+			sb.WriteString("\n\n---\n\n")
+		}
+		for _, content := range body {
+			if content.Published {
+				sb.WriteString("\n\n" + content.Render() + "\n\n")
+				sb.WriteString("---\n\n")
+			}
+		}
+		return sb.String()
+	}
+	return c.RenderMarkdown(body...)
 }
 
 func RenderComponent(path string, c Component) (out string) {

--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -17,6 +17,8 @@ import (
 	"gno.land/p/eve000/event/speaker"
 )
 
+var _ component.EventSchedule = (*Event)(nil)
+
 type Api interface {
 	AddOrganizer(addr std.Address)
 	AddProposer(addr, sender std.Address)
@@ -71,8 +73,6 @@ type Event struct {
 	renderOpts     map[string]interface{}
 	storage        *Storage
 }
-
-var _ component.Component = (*Event)(nil)
 
 func (evt *Event) SetEventName(name string) {
 	evt.Name = name
@@ -167,13 +167,7 @@ func (evt *Event) GetSessions() []*session.Session {
 	})
 	return sessions
 }
-
-// RenderFlyer renders the event flyer with optional body content.
-func (evt *Event) RenderFlyer(body ...component.Content) string {
-	return evt.Flyer().ToMarkdown(body...)
-}
-
-func (evt *Event) Flyer() *flyer.Flyer {
+func (evt *Event) Flyer() component.Component {
 	f := &flyer.Flyer{
 		Name:        evt.Name,
 		Location:    evt.Location,
@@ -185,6 +179,10 @@ func (evt *Event) Flyer() *flyer.Flyer {
 	}
 	f.SetRenderOpts(evt.renderOpts)
 	return f
+}
+
+func (evt *Event) RenderMarkdown(body ...component.Content) string {
+	return evt.Flyer().ToMarkdown(body...)
 }
 
 func (evt *Event) RenderCalendar(path string) string {
@@ -334,21 +332,7 @@ func (evt *Event) ToAnchor() string {
 	return component.StringToAnchor(evt.Name)
 }
 
-func (evt *Event) ToMarkdown(body ...component.Content) string {
-	return evt.Flyer().ToMarkdown(body...)
-}
-
-func (evt *Event) ToSvgDataUrl() string {
-	return evt.Flyer().ToSvgDataUrl()
-}
-
-func (evt *Event) ToSVG() string {
-	return evt.Flyer().ToSVG()
-}
-
 const DateFormatJsonLD = "2006-01-02T15:04:05-07:00"
-
-// FIXME: check schema.org to conform to secondary rules for Cancelled, Postponed, Rescheduled events
 
 func (evt *Event) ToJson() string {
 	var sb strings.Builder

--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -27,12 +27,10 @@ type Api interface {
 	AdminRemoveRole(role string, addr std.Address)
 	AdminSetRole(role string, addr std.Address)
 	AssertAtLeastRole(role string, sender std.Address)
-	Destroy(markdown string)
 	HasRole(role string, addr std.Address) bool
 	JoinAsAttendee()
 	JoinWaitlist()
 	ListRoles() []string
-	Publish(markdown string)
 	RegisterEvent(evt *Event, opts map[string]interface{}) string
 	RemoveOrganizer(addr std.Address)
 	RemoveProposer(addr, sender std.Address)
@@ -48,7 +46,6 @@ type Api interface {
 	SetContent(key, markdown string)
 	SetPatchLevel(level int)
 	SetRoleHandler(role string, fn func(string) bool)
-	Unpublish(key string)
 	UnsetRoleHandler(role string)
 }
 

--- a/projects/gnoland/gno.land/p/eve000/event/register/register.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/register/register.gno
@@ -1,10 +1,10 @@
 package register
 
 import (
+	"net/url"
 	"std"
 	"strconv"
 	"strings"
-	"net/url"
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
@@ -58,7 +58,7 @@ func (r *Registry) Render(path string, body ...component.Content) string {
 	case hasQueryParam(q, "flyer"):
 		return component.RenderComponent(path, evt.Flyer())
 	default:
-		return evt.RenderMarkdown(body...)
+		return component.RenderPage(q.Get("format"), evt, body...)
 	}
 }
 

--- a/projects/gnoland/gno.land/p/eve000/event/register/register.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/register/register.gno
@@ -4,10 +4,12 @@ import (
 	"std"
 	"strconv"
 	"strings"
+	"net/url"
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
 	"gno.land/p/eve000/event"
+	"gno.land/p/eve000/event/component"
 )
 
 type Registry struct {
@@ -16,6 +18,48 @@ type Registry struct {
 	RenderOpts  map[string]interface{}
 	patchLevel  int    // current patch level, used for debugging and content management
 	patchRealm  string // realm that is allowed to update the patch level, used for debugging and content management
+}
+
+func getQueryParam(q url.Values, param string) (string, bool) {
+	if q == nil {
+		return "", false
+	}
+	value := q.Get(param)
+	if value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+func hasQueryParam(q url.Values, param string) bool {
+	_, ok := getQueryParam(q, param)
+	return ok
+}
+
+func (r *Registry) Render(path string, body ...component.Content) string {
+	fullURL := std.CurrentRealm().PkgPath() + path // REVIEW: is this really needed?
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		panic("Error Parsing URL")
+	}
+	q := u.Query()
+	event_id := q.Get("event")
+	if event_id == "" {
+		event_id = r.LiveEventId
+	}
+	evt := r.GetEvent(event_id)
+	switch {
+	case hasQueryParam(q, "session"):
+		return component.RenderComponent(path, evt.GetSession(q.Get("session")))
+	case hasQueryParam(q, "location"):
+		return component.RenderComponent(path, evt.GetLocation(q.Get("location")))
+	case hasQueryParam(q, "speaker"):
+		return component.RenderComponent(path, evt.GetSpeaker(q.Get("speaker")))
+	case hasQueryParam(q, "flyer"):
+		return component.RenderComponent(path, evt.Flyer())
+	default:
+		return evt.RenderMarkdown(body...)
+	}
 }
 
 func NewRegistry(renderOpts map[string]interface{}) *Registry {

--- a/projects/gnoland/gno.land/p/eve000/event/speaker/speaker.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/speaker/speaker.gno
@@ -7,8 +7,6 @@ import (
 	"gno.land/p/eve000/event/component"
 )
 
-// FIXME: add address field
-
 type Speaker struct {
 	Name        string
 	Address     string
@@ -52,7 +50,7 @@ func (s *Speaker) ToMarkdown(_ ...component.Content) string {
 		markdown += "![Picture](" + s.PictureURL + ")\n\n"
 	}
 	if s.Address != "" {
-		markdown += "Address: " + s.Address + "\n\n"
+		markdown += "Address: [" + s.Address + "]( /u/" + s.Address + ")\n\n"
 	}
 	return markdown
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
@@ -74,8 +74,10 @@ func (*App) Render(path string) (out string) {
 		return component.RenderComponent(path, event.GetLocation(q.Get("location")))
 	case hasQueryParam(q, "speaker"):
 		return component.RenderComponent(path, event.GetSpeaker(q.Get("speaker")))
+	case hasQueryParam(q, "flyer"):
+		return component.RenderComponent(path, event.Flyer())
 	default:
-		return event.RenderFlyer(banner)
+		return event.RenderMarkdown(banner)
 	}
 }
 

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
@@ -1,13 +1,10 @@
 package gnolandlaunch
 
 import (
-	"net/url"
 	"std"
 
 	"gno.land/p/eve000/event"
-	"gno.land/p/eve000/event/component"
 	"gno.land/p/eve000/event/register"
-	"gno.land/p/eve000/event/session"
 )
 
 type App struct{}
@@ -17,101 +14,17 @@ var (
 
 	app = &App{}
 
-	staticContent = &component.Content{
-		Published: false,
-		Markdown:  "This page has been disabled",
-	}
-	eventMap = &component.Content{
-		Published: false,
-		Markdown:  "This page has been disabled",
-	}
-
 	realmAllowPrefix = []string{} // realms prefixes that have access to update the registry
 	registry         = &register.Registry{}
 )
 
-func notEmpty(value string) bool {
-	return value != ""
-}
-
-func Render(path string) (out string) {
-	return app.Render(path) + "\n\n" + registry.GetPatchLevel() + "\n\n"
-}
-
-func getQueryParam(q url.Values, param string) (string, bool) {
-	if q == nil {
-		return "", false
-	}
-	value := q.Get(param)
-	if value == "" {
-		return "", false
-	}
-	return value, true
-}
-
-func hasQueryParam(q url.Values, param string) bool {
-	_, ok := getQueryParam(q, param)
-	return ok
-}
-
 func (*App) Render(path string) (out string) {
-	fullURL := std.CurrentRealm().PkgPath() + path
-	u, err := url.Parse(fullURL)
-	if err != nil {
-		panic("Error Parsing URL")
-	}
-	q := u.Query()
-	event_id := q.Get("event")
-	if event_id == "" {
-		event_id = registry.LiveEventId
-	}
-
-	event := registry.GetEvent(event_id)
-	switch {
-	case hasQueryParam(q, "session"):
-		return component.RenderComponent(path, event.GetSession(q.Get("session")))
-	case hasQueryParam(q, "location"):
-		return component.RenderComponent(path, event.GetLocation(q.Get("location")))
-	case hasQueryParam(q, "speaker"):
-		return component.RenderComponent(path, event.GetSpeaker(q.Get("speaker")))
-	case hasQueryParam(q, "flyer"):
-		return component.RenderComponent(path, event.Flyer())
-	default:
-		return event.RenderMarkdown(banner)
-	}
-}
-
-func (*App) Publish(markdown string) {
-	assertAccess()
-	staticContent.Published = true
-	staticContent.Markdown = markdown
-}
-
-func (*App) Destroy(markdown string) {
-	app.Publish(markdown)
-	registry = register.NewRegistry(registry.RenderOpts) // reset the registry to a new instance
-}
-
-func (*App) Unpublish(key string) {
-	assertAccess()
-	switch key {
-	case "map":
-		eventMap.Published = false
-	case "published":
-		staticContent.Published = false
-	case "banner":
-		banner.Published = false
-	default:
-		panic("invalid key: " + key)
-	}
+    return registry.Render(path, banner)
 }
 
 func (*App) SetContent(key, markdown string) {
 	assertAccess()
 	switch key {
-	case "published":
-		staticContent.SetPublished(true)
-		staticContent.SetMarkdown(markdown)
 	case "banner":
 		banner.SetPublished(true)
 		banner.SetMarkdown(markdown)
@@ -204,13 +117,6 @@ func (*App) AssertAtLeastRole(role string, sender std.Address) {
 func (*App) RenderList(role string) string {
 	return acl.RenderList(role)
 }
-
 func (*App) RenderAcl(path string) string {
 	return acl.Render(path)
-}
-
-// REVIEW: should this be added to event.Api interface?
-func (*App) GetSession(id int) *session.Session {
-	// FIXME
-	return registry.GetEvent(registry.LiveEventId).GetSession(string(id))
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
@@ -19,7 +19,7 @@ var (
 )
 
 func (*App) Render(path string) (out string) {
-    return registry.Render(path, banner)
+	return registry.Render(path, banner)
 }
 
 func (*App) SetContent(key, markdown string) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/public.gno
@@ -8,3 +8,7 @@ func JoinWaitlist() {
 func RenderCalendar(path string) string {
 	return app.LiveEvent().RenderCalendar(path)
 }
+
+func Render(path string) (out string) {
+	return app.Render(path) + "\n\n" + registry.GetPatchLevel() + "\n\n"
+}

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
@@ -74,8 +74,10 @@ func (*App) Render(path string) (out string) {
 		return component.RenderComponent(path, event.GetLocation(q.Get("location")))
 	case hasQueryParam(q, "speaker"):
 		return component.RenderComponent(path, event.GetSpeaker(q.Get("speaker")))
+	case hasQueryParam(q, "flyer"):
+		return component.RenderComponent(path, event.Flyer())
 	default:
-		return event.RenderFlyer(banner)
+		return event.RenderMarkdown(banner)
 	}
 }
 

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
@@ -19,7 +19,7 @@ var (
 )
 
 func (*App) Render(path string) (out string) {
-    return registry.Render(path, banner)
+	return registry.Render(path, banner)
 }
 
 func (*App) SetContent(key, markdown string) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
@@ -1,13 +1,10 @@
 package gnoplan
 
 import (
-	"net/url"
 	"std"
 
 	"gno.land/p/eve000/event"
-	"gno.land/p/eve000/event/component"
 	"gno.land/p/eve000/event/register"
-	"gno.land/p/eve000/event/session"
 )
 
 type App struct{}
@@ -17,101 +14,17 @@ var (
 
 	app = &App{}
 
-	staticContent = &component.Content{
-		Published: false,
-		Markdown:  "This page has been disabled",
-	}
-	eventMap = &component.Content{
-		Published: false,
-		Markdown:  "This page has been disabled",
-	}
-
 	realmAllowPrefix = []string{} // realms prefixes that have access to update the registry
 	registry         = &register.Registry{}
 )
 
-func notEmpty(value string) bool {
-	return value != ""
-}
-
-func Render(path string) (out string) {
-	return app.Render(path) + "\n\n" + registry.GetPatchLevel() + "\n\n"
-}
-
-func getQueryParam(q url.Values, param string) (string, bool) {
-	if q == nil {
-		return "", false
-	}
-	value := q.Get(param)
-	if value == "" {
-		return "", false
-	}
-	return value, true
-}
-
-func hasQueryParam(q url.Values, param string) bool {
-	_, ok := getQueryParam(q, param)
-	return ok
-}
-
 func (*App) Render(path string) (out string) {
-	fullURL := std.CurrentRealm().PkgPath() + path
-	u, err := url.Parse(fullURL)
-	if err != nil {
-		panic("Error Parsing URL")
-	}
-	q := u.Query()
-	event_id := q.Get("event")
-	if event_id == "" {
-		event_id = registry.LiveEventId
-	}
-
-	event := registry.GetEvent(event_id)
-	switch {
-	case hasQueryParam(q, "session"):
-		return component.RenderComponent(path, event.GetSession(q.Get("session")))
-	case hasQueryParam(q, "location"):
-		return component.RenderComponent(path, event.GetLocation(q.Get("location")))
-	case hasQueryParam(q, "speaker"):
-		return component.RenderComponent(path, event.GetSpeaker(q.Get("speaker")))
-	case hasQueryParam(q, "flyer"):
-		return component.RenderComponent(path, event.Flyer())
-	default:
-		return event.RenderMarkdown(banner)
-	}
-}
-
-func (*App) Publish(markdown string) {
-	assertAccess()
-	staticContent.Published = true
-	staticContent.Markdown = markdown
-}
-
-func (*App) Destroy(markdown string) {
-	app.Publish(markdown)
-	registry = register.NewRegistry(registry.RenderOpts) // reset the registry to a new instance
-}
-
-func (*App) Unpublish(key string) {
-	assertAccess()
-	switch key {
-	case "map":
-		eventMap.Published = false
-	case "published":
-		staticContent.Published = false
-	case "banner":
-		banner.Published = false
-	default:
-		panic("invalid key: " + key)
-	}
+    return registry.Render(path, banner)
 }
 
 func (*App) SetContent(key, markdown string) {
 	assertAccess()
 	switch key {
-	case "published":
-		staticContent.SetPublished(true)
-		staticContent.SetMarkdown(markdown)
 	case "banner":
 		banner.SetPublished(true)
 		banner.SetMarkdown(markdown)
@@ -204,13 +117,6 @@ func (*App) AssertAtLeastRole(role string, sender std.Address) {
 func (*App) RenderList(role string) string {
 	return acl.RenderList(role)
 }
-
 func (*App) RenderAcl(path string) string {
 	return acl.Render(path)
-}
-
-// REVIEW: should this be added to event.Api interface?
-func (*App) GetSession(id int) *session.Session {
-	// FIXME
-	return registry.GetEvent(registry.LiveEventId).GetSession(string(id))
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/public.gno
@@ -8,3 +8,7 @@ func JoinBeta() {
 func RenderCalendar(path string) string {
 	return app.LiveEvent().RenderCalendar(path)
 }
+
+func Render(path string) (out string) {
+	return app.Render(path) + "\n\n" + registry.GetPatchLevel() + "\n\n"
+}

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
@@ -74,8 +74,10 @@ func (*App) Render(path string) (out string) {
 		return component.RenderComponent(path, event.GetLocation(q.Get("location")))
 	case hasQueryParam(q, "speaker"):
 		return component.RenderComponent(path, event.GetSpeaker(q.Get("speaker")))
+	case hasQueryParam(q, "flyer"):
+		return component.RenderComponent(path, event.Flyer())
 	default:
-		return event.RenderFlyer(banner)
+		return event.RenderMarkdown(banner)
 	}
 }
 

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
@@ -19,7 +19,7 @@ var (
 )
 
 func (*App) Render(path string) (out string) {
-    return registry.Render(path, banner)
+	return registry.Render(path, banner)
 }
 
 func (*App) SetContent(key, markdown string) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
@@ -1,13 +1,10 @@
 package onsite
 
 import (
-	"net/url"
 	"std"
 
 	"gno.land/p/eve000/event"
-	"gno.land/p/eve000/event/component"
 	"gno.land/p/eve000/event/register"
-	"gno.land/p/eve000/event/session"
 )
 
 type App struct{}
@@ -17,101 +14,17 @@ var (
 
 	app = &App{}
 
-	staticContent = &component.Content{
-		Published: false,
-		Markdown:  "This page has been disabled",
-	}
-	eventMap = &component.Content{
-		Published: false,
-		Markdown:  "This page has been disabled",
-	}
-
 	realmAllowPrefix = []string{} // realms prefixes that have access to update the registry
 	registry         = &register.Registry{}
 )
 
-func notEmpty(value string) bool {
-	return value != ""
-}
-
-func Render(path string) (out string) {
-	return app.Render(path) + "\n\n" + registry.GetPatchLevel() + "\n\n"
-}
-
-func getQueryParam(q url.Values, param string) (string, bool) {
-	if q == nil {
-		return "", false
-	}
-	value := q.Get(param)
-	if value == "" {
-		return "", false
-	}
-	return value, true
-}
-
-func hasQueryParam(q url.Values, param string) bool {
-	_, ok := getQueryParam(q, param)
-	return ok
-}
-
 func (*App) Render(path string) (out string) {
-	fullURL := std.CurrentRealm().PkgPath() + path
-	u, err := url.Parse(fullURL)
-	if err != nil {
-		panic("Error Parsing URL")
-	}
-	q := u.Query()
-	event_id := q.Get("event")
-	if event_id == "" {
-		event_id = registry.LiveEventId
-	}
-
-	event := registry.GetEvent(event_id)
-	switch {
-	case hasQueryParam(q, "session"):
-		return component.RenderComponent(path, event.GetSession(q.Get("session")))
-	case hasQueryParam(q, "location"):
-		return component.RenderComponent(path, event.GetLocation(q.Get("location")))
-	case hasQueryParam(q, "speaker"):
-		return component.RenderComponent(path, event.GetSpeaker(q.Get("speaker")))
-	case hasQueryParam(q, "flyer"):
-		return component.RenderComponent(path, event.Flyer())
-	default:
-		return event.RenderMarkdown(banner)
-	}
-}
-
-func (*App) Publish(markdown string) {
-	assertAccess()
-	staticContent.Published = true
-	staticContent.Markdown = markdown
-}
-
-func (*App) Destroy(markdown string) {
-	app.Publish(markdown)
-	registry = register.NewRegistry(registry.RenderOpts) // reset the registry to a new instance
-}
-
-func (*App) Unpublish(key string) {
-	assertAccess()
-	switch key {
-	case "map":
-		eventMap.Published = false
-	case "published":
-		staticContent.Published = false
-	case "banner":
-		banner.Published = false
-	default:
-		panic("invalid key: " + key)
-	}
+    return registry.Render(path, banner)
 }
 
 func (*App) SetContent(key, markdown string) {
 	assertAccess()
 	switch key {
-	case "published":
-		staticContent.SetPublished(true)
-		staticContent.SetMarkdown(markdown)
 	case "banner":
 		banner.SetPublished(true)
 		banner.SetMarkdown(markdown)
@@ -204,13 +117,6 @@ func (*App) AssertAtLeastRole(role string, sender std.Address) {
 func (*App) RenderList(role string) string {
 	return acl.RenderList(role)
 }
-
 func (*App) RenderAcl(path string) string {
 	return acl.Render(path)
-}
-
-// REVIEW: should this be added to event.Api interface?
-func (*App) GetSession(id int) *session.Session {
-	// FIXME
-	return registry.GetEvent(registry.LiveEventId).GetSession(string(id))
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/public.gno
@@ -3,3 +3,7 @@ package onsite
 func RenderCalendar(path string) string {
 	return app.LiveEvent().RenderCalendar(path)
 }
+
+func Render(path string) (out string) {
+	return app.Render(path) + "\n\n" + registry.GetPatchLevel() + "\n\n"
+}

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/public.gno
@@ -80,11 +80,6 @@ func AssertAtLeastRole(realmPath string, role string, sender std.Address) {
 	Eve(realmPath).AssertAtLeastRole(role, sender)
 }
 
-// Destroy removes all data in the event realm and publishes a markdown message in it's place.
-func Destroy(realmPath string, markdown string) {
-	Eve(realmPath).Destroy(markdown)
-}
-
 // HasRole checks if the given address has the specified role in the event realm.
 func HasRole(realmPath string, role string, addr std.Address) bool {
 	return Eve(realmPath).HasRole(role, addr)
@@ -103,11 +98,6 @@ func JoinWaitlist(realmPath string) {
 // ListRoles returns a list of roles in the event realm.
 func ListRoles(realmPath string) []string {
 	return Eve(realmPath).ListRoles()
-}
-
-// Publish publishes a markdown message in the event realm.
-func Publish(realmPath string, markdown string) {
-	Eve(realmPath).Publish(markdown)
 }
 
 // RegisterEvent registers an event in the event realm with the given options.
@@ -178,11 +168,6 @@ func SetPatchLevel(realmPath string, level int) {
 // SetRoleHandler sets a handler function for a specific role in the event realm.
 func SetRoleHandler(realmPath string, role string, fn func(string) bool) {
 	Eve(realmPath).SetRoleHandler(role, fn)
-}
-
-// Unpublish removes the content associated with the given key in the event realm.
-func Unpublish(realmPath string, key string) {
-	Eve(realmPath).Unpublish(key)
 }
 
 // UnsetRoleHandler removes the handler function for a specific role in the event realm.

--- a/projects/gnoland/gno.land/r/linker000/discord/role/v0/render.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/role/v0/render.gno
@@ -77,7 +77,7 @@ func renderListLinkedRoles(w *mux.ResponseWriter, r *mux.Request) {
 
 func renderClaim(w *mux.ResponseWriter, r *mux.Request) {
 	encodedClaim := r.GetVar("encodedClaim")
-	
+
 	// Check if this is an unlink operation
 	isUnlink := r.Query.Get("unlink") == "true"
 

--- a/projects/gnoland/gno.land/r/linker000/discord/user/v0/render.gno
+++ b/projects/gnoland/gno.land/r/linker000/discord/user/v0/render.gno
@@ -65,7 +65,7 @@ func renderLinkByGnoAddr(w *mux.ResponseWriter, r *mux.Request) {
 
 func renderClaim(w *mux.ResponseWriter, r *mux.Request) {
 	encodedClaim := r.GetVar("encodedClaim")
-	
+
 	// Check if this is an unlink operation
 	isUnlink := r.Query.Get("unlink") == "true"
 

--- a/projects/gnoland/gno.land/r/metamodel000/eve.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/eve.gno
@@ -18,7 +18,6 @@ The relationships between these files are as follows:
 - **boundby**: App is bound by the rules of the ACL.
 `
 
-
 func init() {
 	eveModel := eve()
 


### PR DESCRIPTION
separate the notion of Page and Component

can now pass ?format=json to see the JsonLD data (on event)

This emulates what we'd do on a search-engine indexed page to nest structure data