### PR TITLE
refactor registry

### DIFF
--- a/projects/gnoland/gno.land/p/metamodel000/registry.gno
+++ b/projects/gnoland/gno.land/p/metamodel000/registry.gno
@@ -1,0 +1,247 @@
+package metamodel
+
+import (
+	"net/url"
+	"std"
+	"strconv"
+	"strings"
+	"time"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ufmt"
+	"gno.land/p/rss000/feed"
+)
+
+type ContentBlock = func(path string) string
+type RegistryCallback = func(key string, value interface{}) bool
+type RegistryMatcher = func(value interface{}) bool
+
+type Registry struct {
+	tree          *avl.Tree
+	allowPrefixes []string
+	renderOpts    map[string]interface{}
+}
+
+func NewRegistry(allowedPrefixes []string, renderOpts map[string]interface{}) *Registry {
+	return &Registry{
+		tree:          avl.NewTree(),
+		allowPrefixes: allowedPrefixes,
+		renderOpts: renderOpts,
+	}
+}
+
+func (r *Registry) hasAllowedPrefix() bool {
+	prevRealm := std.PreviousRealm()
+	for _, callerPath := range r.allowPrefixes {
+		if strings.HasPrefix(prevRealm.PkgPath(), callerPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Registry) assertAccess() {
+	if !r.hasAllowedPrefix() {
+		panic("access denied: " + std.PreviousRealm().PkgPath() +
+			" realm must match an allowed prefix:[" + strings.Join(r.allowPrefixes, ",") + "]")
+	}
+}
+
+func (r *Registry) Register(key string, obj interface{}) {
+	r.assertAccess()
+	r.register(key, obj)
+}
+
+func (r *Registry) register(key string, obj interface{}) {
+	switch obj := obj.(type) {
+	case ContentBlock:
+		r.tree.Set(key, obj)
+	case *Model:
+		r.tree.Set(key, ModelFactory(func(_ ...interface{}) *Model {
+			return obj
+		}))
+	case ModelFunc:
+		r.tree.Set(key, ModelFactory(func(_ ...interface{}) *Model {
+			return obj()
+		}))
+	case ModelFactory:
+		r.tree.Set(key, obj)
+	default:
+		panic(ufmt.Sprintf("Invalid type for key %s: %T", key, obj))
+	}
+}
+
+func (r *Registry) Preview(key, path string) string {
+	obj, ok := r.tree.Get(key)
+	if !ok {
+		panic("Key not found: " + key)
+	}
+
+	lineCount := 3
+
+	switch obj := obj.(type) {
+	case ContentBlock:
+		content := obj(path)
+		lines := strings.Split(content, "\n")
+		if len(lines) > lineCount {
+			return strings.Join(lines[:lineCount], "\n") + "\n"
+		}
+		return content
+	case ModelFactory:
+		model := obj()
+		if binding, ok := model.Binding.(ContentBlock); ok {
+			content := binding(path)
+			lines := strings.Split(content, "\n")
+			if len(lines) > lineCount {
+				return strings.Join(lines[:lineCount], "\n") + "\n"
+			}
+			return content
+		}
+		return model.ToMarkdown()
+	default:
+		panic("Key is not a ContentBlock or ModelFactory: " + key)
+	}
+}
+
+func (r *Registry) Content(key, path string) string {
+	obj, ok := r.tree.Get(key)
+	if !ok {
+		panic("Key not found: " + key)
+	}
+
+	switch obj := obj.(type) {
+	case ContentBlock:
+		return obj(path)
+	case ModelFactory:
+		model := obj()
+		if binding, ok := model.Binding.(ContentBlock); ok {
+			return binding(path)
+		}
+		return model.ToMarkdown()
+	default:
+		panic("Key is not a ContentBlock or ModelFactory: " + key)
+	}
+}
+
+func (r *Registry) Model(key string, inputs ...interface{}) *Model {
+	factory, ok := r.tree.Get(key)
+	if !ok {
+		panic("Key not found: " + key)
+	}
+
+	if modelFactory, ok := factory.(ModelFactory); ok {
+		return modelFactory(inputs...)
+	}
+	panic("Key is not a ModelFactory: " + key)
+}
+
+func (r *Registry) Iterate(callback RegistryCallback, matcher RegistryMatcher) {
+	r.tree.IterateByOffset(0, r.tree.Size(), func(key string, value interface{}) bool {
+		if matcher(value) {
+			return callback(key, value)
+		}
+		return false
+	})
+}
+
+// TODO: test + use this w/ a feed
+func (r *Registry) getItems() []*feed.Item {
+	var items []*feed.Item
+	host := r.renderOpts["host"].(string)
+
+	r.Iterate(func(key string, value interface{}) bool {
+		if _, ok := value.(*Model); ok {
+			items = append(items, &feed.Item{
+				Title:       key,
+				Link:        &feed.Link{Href: host + "r/metamodel000:" + key},
+				Description: "",
+				Content:     "",
+				PubDate:     time.Now(),
+			})
+		} else {
+			panic("registry value is not an Item: " + key)
+		}
+		return false
+	}, HasModelApi)
+
+	return items
+}
+
+func (r *Registry) Render(path string) string {
+	u := parseQuery(path)
+	if idx, ok := u["i"]; ok && len(idx) > 0 {
+		return r.renderItem(idx[0], u)
+	}
+	return r.renderIndex()
+}
+
+func (r *Registry) renderItem(indexStr string, u url.Values) string {
+	index, _ := strconv.Atoi(indexStr)
+	i := index % r.tree.Size()
+	key, _ := r.tree.GetByIndex(i)
+
+	var sb strings.Builder
+	sb.WriteString("### " + upcaseWords(key) + "\n\n")
+	sb.WriteString(r.renderNavigation(i, u))
+	sb.WriteString(r.Content(key, ""))
+	return sb.String()
+}
+
+func (r *Registry) renderNavigation(i int, u url.Values) string {
+	var sb strings.Builder
+	prev := (i - 1 + r.tree.Size()) % r.tree.Size()
+	next := (i + 1) % r.tree.Size()
+
+	sb.WriteString("[<-prev](?i=" + ufmt.Sprintf("%d", prev) + ") ")
+	sb.WriteString(ufmt.Sprintf("%d/%d", i, r.tree.Size()-1))
+	sb.WriteString(" [next->](?i=" + ufmt.Sprintf("%d", next) + ")\n\n")
+	return sb.String()
+}
+
+func (r *Registry) thumbnail(key string, obj interface{}) string {
+	switch obj := obj.(type) {
+	case ModelFactory:
+		model := obj()
+		return "![" + key + "](" + model.ThumbnailDataUrl() + ")\n" +
+			r.Preview(key, "") + "\n"
+	case ContentBlock:
+		return "[no thumbnail]\n"
+	default:
+		return "[default]\n"
+	}
+}
+
+func (r *Registry) renderIndex() string {
+	var sb strings.Builder
+	sb.WriteString("### Metamodel Index\n\n")
+	sb.WriteString("This is the index of the metamodel. " +
+		"You can use the `?i=` query parameter to navigate through the models.\n\n")
+	sb.WriteString("Available models:\n\n")
+
+	for i := 0; i < r.tree.Size(); i++ {
+		key, obj := r.tree.GetByIndex(i)
+		sb.WriteString("- [" + upcaseWords(key) + "](?i=" + ufmt.Sprintf("%d", i) + ")\n")
+		sb.WriteString(r.thumbnail(key, obj))
+	}
+	return sb.String()
+}
+
+func parseQuery(path string) url.Values {
+	if len(path) > 0 && path[0] == '?' {
+		u, err := url.Parse(std.CurrentRealm().PkgPath() + path)
+		if err == nil {
+			return u.Query()
+		}
+	}
+	return url.Values{}
+}
+
+func upcaseWords(s string) string {
+	words := strings.Fields(s)
+	for i, word := range words {
+		if len(word) > 0 {
+			words[i] = strings.ToUpper(string(word[0])) + word[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}

--- a/projects/gnoland/gno.land/r/metamodel000/coffeeshop.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/coffeeshop.gno
@@ -4,12 +4,17 @@ import (
 	mm "gno.land/p/metamodel000"
 )
 
+var coffeeShopDescription = `
+This is a model of a coffee shop process, which includes the following steps:
+
+`
+
 func init() {
 	coffeeShopModel := coffeeShop()
-
-	register("coffeeShop", func(_ string) string {
-		return coffeeShopModel.ToMarkdown()
-	})
+	coffeeShopModel.Binding = func(_ string) string {
+		return coffeeShopDescription + coffeeShopModel.ToMarkdown()
+	}
+	register("coffeeShop", coffeeShopModel)
 }
 
 func coffeeShop() *mm.Model {

--- a/projects/gnoland/gno.land/r/metamodel000/eve.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/eve.gno
@@ -20,10 +20,10 @@ The relationships between these files are as follows:
 
 func init() {
 	eveModel := eve()
-
-	register("EventFolderLayout", func(_ string) string {
+	eveModel.Binding = func(_ string) string {
 		return folderLayout + eveModel.ToMarkdown()
-	})
+	}
+	register("EventFolderLayout", eveModel)
 }
 
 // eve model shows the layout of the event folder

--- a/projects/gnoland/gno.land/r/metamodel000/index.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/index.gno
@@ -1,217 +1,35 @@
 package metamodel
 
 import (
-	"net/url"
-	"std"
-	"strconv"
-	"strings"
-	"time"
-
-	"gno.land/p/demo/avl"
-	"gno.land/p/demo/ufmt"
 	mm "gno.land/p/metamodel000"
-	"gno.land/p/rss000/feed"
 )
 
 var (
-	registry         = avl.NewTree()
-	realmAllowPrefix = []string{}
-	displayPaths     = []string{}
-	renderOpts       = map[string]interface{}{
-		"host": "http://",
-	}
+    renderOpts = map[string]interface{}{
+        "Title":       "Metamodel000",
+        "Description": "A metamodel for Gno.land, providing various models and examples.",
+        "Author":      "Gno.land Team",
+        "Version":     "0.0.1",
+        "Date":        "2023-10-01",
+    }
+
+    authorizedPaths = []string{
+        "gno.land/r/metamodel000",
+        "gno.land/p/metamodel000",
+        "",
+    }
+
+    registry = mm.NewRegistry(authorizedPaths, renderOpts)
 )
 
-func init() {
-	realmAllowPrefix = append(realmAllowPrefix, std.CurrentRealm().PkgPath()+"/")
-}
-
-type ContentBlock = func(path string) string
-
-func hasAllowedPrefix() bool {
-	prevRealm := std.PreviousRealm()
-	for _, callerPath := range realmAllowPrefix {
-		if strings.HasPrefix(prevRealm.PkgPath(), callerPath) {
-			return true
-		}
-	}
-	return false
-}
-
-func assertAccess() {
-	if !hasAllowedPrefix() {
-		panic("access denied: " + std.PreviousRealm().PkgPath() +
-			" realm must match an allowed prefix:[" + strings.Join(realmAllowPrefix, ",") + "]")
-	}
-}
-
 func Register(cur realm, key string, obj interface{}) {
-	assertAccess()
-	register(key, obj)
+	registry.Register(key, obj)
 }
 
 func register(key string, obj interface{}) {
-	switch obj := obj.(type) {
-	case ContentBlock:
-		registry.Set(key, obj)
-	case *mm.Model:
-		registry.Set(key, mm.ModelFactory(func(_ ...interface{}) *mm.Model {
-			return obj
-		}))
-	case mm.ModelFunc:
-		registry.Set(key, mm.ModelFactory(func(_ ...interface{}) *mm.Model {
-			return obj()
-		}))
-	case mm.ModelFactory:
-		registry.Set(key, obj)
-	default:
-		panic(ufmt.Sprintf("Invalid type for key %s: %T", key, obj))
-	}
-	displayPaths = append(displayPaths, key)
-}
-
-func Content(key, path string) string {
-	obj, ok := registry.Get(key)
-	if !ok {
-		panic("Key not found: " + key)
-	}
-
-	switch obj := obj.(type) {
-	case ContentBlock:
-		return obj(path)
-	case mm.ModelFactory:
-		model := obj()
-		if binding, ok := model.Binding.(ContentBlock); ok {
-			return binding(path)
-		}
-		return model.ToMarkdown()
-	default:
-		panic("Key is not a ContentBlock or ModelFactory: " + key)
-	}
-}
-
-func Model(key string, inputs ...interface{}) *mm.Model {
-	factory, ok := registry.Get(key)
-	if !ok {
-		panic("Key not found: " + key)
-	}
-
-	if modelFactory, ok := factory.(mm.ModelFactory); ok {
-		return modelFactory(inputs...)
-	}
-	panic("Key is not a ModelFactory: " + key)
-}
-
-func upcaseWords(s string) string {
-	words := strings.Fields(s)
-	for i, word := range words {
-		if len(word) > 0 {
-			words[i] = strings.ToUpper(string(word[0])) + word[1:]
-		}
-	}
-	return strings.Join(words, " ")
-}
-
-type RegistryCallback = func(key string, value interface{}) bool
-type RegistryMatcher = func(value interface{}) bool
-
-func IterateRegistry(callback RegistryCallback, matcher RegistryMatcher) {
-	registry.IterateByOffset(0, registry.Size(), func(key string, value interface{}) bool {
-		if matcher(value) {
-			return callback(key, value)
-		}
-		return false
-	})
-}
-
-func getItems() []*feed.Item {
-	var items []*feed.Item
-	host := renderOpts["host"].(string)
-
-	IterateRegistry(func(key string, value interface{}) bool {
-		if _, ok := value.(*mm.Model); ok {
-			items = append(items, &feed.Item{
-				Title:       key,
-				Link:        &feed.Link{Href: host + "r/metamodel000:" + key},
-				Description: "",
-				Content:     "",
-				PubDate:     time.Now(),
-			})
-		} else {
-			panic("registry value is not an Item: " + key)
-		}
-		return false
-	}, mm.HasModelApi)
-
-	return items
-}
-
-func parseQuery(path string) url.Values {
-	if len(path) > 0 && path[0] == '?' {
-		u, err := url.Parse(std.CurrentRealm().PkgPath() + path)
-		if err == nil {
-			return u.Query()
-		}
-	}
-	return url.Values{}
+	registry.Register(key, obj)
 }
 
 func Render(path string) string {
-	u := parseQuery(path)
-	if idx, ok := u["i"]; ok && len(idx) > 0 {
-		return renderItem(idx[0], u)
-	}
-	return renderIndex()
-}
-
-func renderItem(indexStr string, u url.Values) string {
-	index, _ := strconv.Atoi(indexStr)
-	i := index % registry.Size()
-	key, _ := registry.GetByIndex(i)
-
-	var sb strings.Builder
-	sb.WriteString("### " + upcaseWords(key) + "\n\n")
-	sb.WriteString(renderNavigation(i, u))
-	sb.WriteString(Content(key, ""))
-	return sb.String()
-}
-
-func renderNavigation(i int, u url.Values) string {
-	var sb strings.Builder
-	prev := (i - 1 + registry.Size()) % registry.Size()
-	next := (i + 1) % registry.Size()
-
-	sb.WriteString("[<-prev](?i=" + ufmt.Sprintf("%d", prev) + ") ")
-	sb.WriteString(ufmt.Sprintf("%d/%d", i, registry.Size()-1))
-	sb.WriteString(" [next->](?i=" + ufmt.Sprintf("%d", next) + ")\n\n")
-	return sb.String()
-}
-
-func thumbnail(key string, obj interface{}) string {
-	switch obj := obj.(type) {
-	case mm.ModelFactory:
-		model := obj() // Call the ModelFactory function
-		return "![" + key + "](" + model.ThumbnailDataUrl() + ")\n"
-	case ContentBlock:
-		return "[no thumbnail]\n"
-	default:
-		// If the object does not have a thumbnail, return an empty string.
-		return "[default]\n"
-	}
-}
-
-func renderIndex() string {
-	var sb strings.Builder
-	sb.WriteString("### Metamodel Index\n\n")
-	sb.WriteString("This is the index of the metamodel. " +
-		"You can use the `?i=` query parameter to navigate through the models.\n\n")
-	sb.WriteString("Available models:\n\n")
-
-	for i := 0; i < registry.Size(); i++ {
-		key, obj := registry.GetByIndex(i)
-		sb.WriteString("- [" + upcaseWords(key) + "](?i=" + ufmt.Sprintf("%d", i) + ")\n")
-		sb.WriteString("  - [Link to model](./metamodel000:" + key + ")\n")
-		sb.WriteString(thumbnail(key, obj))
-	}
-	return sb.String()
+	return registry.Render(path)
 }

--- a/projects/gnoland/gno.land/r/metamodel000/konami.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/konami.gno
@@ -2,11 +2,18 @@ package metamodel
 
 import mm "gno.land/p/metamodel000"
 
+var konamiCodeDescription = `
+This is a model of the Konami Code, a famous cheat code used in many video games
+and pop culture references. The code is typically entered using a game controller and consists of a sequence of directional inputs and button presses.
+
+`
+
 func init() {
 	model := konamiCodeModel()
-	register("konamiCode", func(_ string) string {
-		return model.ToMarkdown()
-	})
+	model.Binding = func(_ string) string {
+		return konamiCodeDescription + model.ToMarkdown()
+	}
+	register("konamiCode", model)
 }
 
 func konamiCodeModel() *mm.Model {

--- a/projects/gnoland/gno.land/r/metamodel000/pscore.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/pscore.gno
@@ -15,11 +15,11 @@ These scores are processed by a formal optimization model
 `
 
 func init() {
-	exampleModel := pScoreVoting(100_000, proposals)
-
-	register("pscore", func(_ string) string {
-		return overview + exampleModel.ToMarkdown()
-	})
+	m := pScoreVoting(100_000, proposals)
+	m.Binding = func(_ string) string {
+		return overview + m.ToMarkdown()
+	}
+	register("pScoreVoting", m)
 }
 
 func pScoreVoting(budget int, proposals []Proposal) *mm.Model {

--- a/projects/gnoland/gno.land/r/metamodel000/tictactoe.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/tictactoe.gno
@@ -2,6 +2,11 @@ package metamodel
 
 import mm "gno.land/p/metamodel000"
 
+var ticTacToeDescription = `
+This Petri net models the flow of a Tic Tac Toe game using places and transitions to represent board states and player actions. The structure supports two distinct but compatible interpretations:
+
+`
+
 var ticTacToeNotes = `
 This Petri net models the flow of a Tic Tac Toe game using places and transitions to represent board states and player actions. The structure supports two distinct but compatible interpretations:
 
@@ -53,7 +58,7 @@ The Petri net’s native concurrency also reveals how multiple board positions c
 func init() {
 	model := ticTacToe()
 	model.Binding = func(_ string) string {
-		return model.ToMarkdown() + ticTacToeNotes
+		return ticTacToeDescription + model.ToMarkdown() + ticTacToeNotes
 	}
 	register("TicTacToe", model)
 }

--- a/projects/gnoland/gno.land/r/metamodel000/transfer.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/transfer.gno
@@ -9,6 +9,11 @@ import (
 
 // TODO: make this form populate from URL http://127.0.0.1:8888/r/metamodel000?amount=3&toAddress=g1e8vw6gh284q7ggzqs8ne6r8j9aqhnmvl6rzzmz
 
+var transferDescription = `
+This is a model to transfer tokens from a wallet to a specified address.
+
+`
+
 var transferForm = `
 <gno-form>
     <gno-input name="amount" placeholder="3" />
@@ -19,7 +24,7 @@ var transferForm = `
 func init() {
 	exampleModel := transfer("g1e8vw6gh284q7ggzqs8ne6r8j9aqhnmvl6rzzmz", "PAY2ADDR", 3)
 	exampleModel.Binding = func(_ string) string {
-		return transferForm + exampleModel.ToMarkdown()
+		return transferDescription + transferForm + exampleModel.ToMarkdown()
 	}
 	register("transfer", exampleModel)
 }


### PR DESCRIPTION
- pulls registry operations into a class at /p/metamodel
- visual adjustments - now showing first 3 lines of bound content `m.Binding.(ContentBlock)(path)`

NOTE: that the Binding interfaces is meant to be a generic hook allowing association with sub-components etc..

This allows us to the model intuition to understand the Bound logic and content.