### PR TITLE
Feat/support calendar links

### DIFF
--- a/projects/gnoland/gno.land/p/eve000/event/component/calendar.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/calendar.gno
@@ -1,0 +1,102 @@
+package component
+
+import (
+    "net/url"
+    "strings"
+    "strconv"
+    "time"
+
+    "gno.land/p/demo/ufmt"
+)
+
+func CalenderDataUrl(path string, a *Flyer) string {
+    if path == "" {
+        path = "?format=ics"
+    }
+	data := IcsCalendarFile(path, a)
+	return "data:text/calendar;charset=utf-8," + url.QueryEscape(data)
+}
+
+func IcsCalendarFile(path string, a *Flyer) string {
+	var f = ufmt.Sprintf
+	var b strings.Builder
+	w := func(s string) {
+		b.WriteString(s + "\n")
+	}
+
+	q := ParseQuery(path)
+	sessionIDs := q["session"]
+	format := strings.ToLower(q.Get("format"))
+
+	useAll := len(sessionIDs) == 0
+	allowed := make(map[string]bool)
+	for _, id := range sessionIDs {
+		allowed[id] = true
+	}
+	include := func(id string) bool { return useAll || allowed[id] }
+
+	switch format {
+	case "json":
+		b.WriteString(a.ToJson())
+		return b.String()
+
+	case "ics":
+		w("BEGIN:VCALENDAR")
+		w("VERSION:2.0")
+		w("CALSCALE:GREGORIAN")
+		w("PRODID:-//gno.land//Launch Calendar//EN")
+		w("METHOD:PUBLISH\n")
+
+		w("BEGIN:VEVENT")
+		w(f("UID:event-%s@%s", slugify(a.Name), "gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar"))
+		w("SEQUENCE:0")
+		w(f("DTSTAMP:%s", time.Now().UTC().Format("20060102T150405Z")))
+		w(f("DTSTART;VALUE=DATE:%s", a.StartDate.Format("20060102")))
+		w(f("DTEND;VALUE=DATE:%s", a.StartDate.AddDate(0, 0, 1).Format("20060102"))) // 👈 Fix: DTEND is exclusive
+		w(f("SUMMARY:%s", a.Name))
+		w(f("DESCRIPTION:%s", a.Description))
+		if a.Location != nil && a.Location.Name != "" {
+			w(f("LOCATION:%s", a.Location.Name))
+		}
+		w("END:VEVENT\n")
+
+		for i, s := range a.Sessions {
+			id := Pad3(strconv.Itoa(i))
+			if !include(id) {
+				continue
+			}
+
+			w("BEGIN:VEVENT")
+			w(f("UID:%s-%d@%s",
+				slugify(s.Title)[:5],
+				s.StartTime.Unix(),
+				"gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar",
+			))
+			w(f("SEQUENCE:%d", s.Sequence))
+			w(f("DTSTAMP:%s", time.Now().UTC().Format("20060102T150405Z")))
+			w(f("DTSTART:%s", s.StartTime.UTC().Format("20060102T150000Z")))
+			w(f("DTEND:%s", s.EndTime.UTC().Format("20060102T150000Z")))
+			w(f("SUMMARY:%s", s.Title))
+			w(f("DESCRIPTION:%s", s.Description))
+			w(f("LOCATION:%s", s.Location.Name))
+			if s.Cancelled {
+				w("STATUS:CANCELLED")
+			}
+			w("END:VEVENT\n")
+		}
+
+		w("END:VCALENDAR")
+		return b.String()
+
+	default:
+		w(f("# %s\n\n%s", a.Name, a.Description))
+		for i, s := range a.Sessions {
+			id := Pad3(strconv.Itoa(i))
+			if !include(id) {
+				continue
+			}
+			w(s.ToMarkdown())
+		}
+		return b.String()
+	}
+}

--- a/projects/gnoland/gno.land/p/eve000/event/component/component.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/component.gno
@@ -1,8 +1,9 @@
 package component
 
 import (
+    "std"
 	"net/url"
-	"std"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -13,24 +14,12 @@ import (
 
 // Interfaces
 
-type EventSchedule interface {
-	Flyer() *Flyer
-	ToJson() string   // object representation of flyer
-	ToJsonLD() string // schema.org compatible event object
-	RenderMarkdown(body ...Content) string
-	RenderCalendar(string) string
-	// TODO: support more formats
-	// RenderFeed(string) string
-	// RenderFrame(string) string
-}
-
-// TODO: add a banner view suitable to nest in another realm
-type Banner interface {
-	RenderBanner(body ...Content) string
+type IcsFileProvider interface {
+    ToIcs() string // returns the content of the ICS file
 }
 
 type ContentProvider interface {
-    Render(path ...string) string
+	Render(path ...string) string
 }
 
 type JsonLdProvider interface {
@@ -56,13 +45,9 @@ type Component interface {
 
 // Types
 
-// Event is a schema.org compatible status string
 type EventStatus string
-
-// EventAttendanceMode is a schema.org compatible attendance mode string
 type EventAttendanceMode string
 
-// Content is a user-editable content struct.
 type Content struct {
 	Published bool
 	Markdown  string
@@ -87,7 +72,7 @@ const (
 	MixedEventAttendanceMode   EventAttendanceMode = "https://schema.org/MixedEventAttendanceMode"
 )
 
-// Methods
+// Content Methods
 
 func (c *Content) SetPublished(published bool) {
 	c.Published = published
@@ -97,58 +82,46 @@ func (c *Content) SetMarkdown(markdown string) {
 	c.Markdown = markdown
 }
 
-// Render displays stored content or calls the callback function if provided.
 func (c *Content) Render(path ...string) string {
-	if !c.Published || c.Markdown == "" && c.Callback == nil {
+	if !c.Published || (c.Markdown == "" && c.Callback == nil) {
 		return ""
 	}
 	if c.Callback != nil {
 		if len(path) > 0 {
 			return c.Callback(path[0])
-		} else {
-			return c.Callback("")
 		}
+		return c.Callback("")
 	}
 	return c.Markdown
 }
 
-// Functions
+// Rendering Functions
 
 func RenderPage(path string, c interface{}, body ...Content) string {
 	q := ParseQuery(path)
 	format := q.Get("format")
-	if jsonProvider, ok := c.(JsonProvider); ok  && format == "json" {
-		var sb strings.Builder
-		sb.WriteString("```\n\n" + jsonProvider.ToJson() + "\n\n```")
-		if len(body) > 0 {
-			sb.WriteString("\n\n---\n\n")
-		}
-		for _, content := range body {
-			if content.Published {
-				sb.WriteString("\n\n" + content.Render() + "\n\n")
-				sb.WriteString("---\n\n")
-			}
-		}
-		return sb.String()
+
+	if c == nil {
+        panic("RenderPage: component is nil")
+    }
+
+	switch {
+	case format == "ics" && implementsIcsFileProvider(c):
+		return renderIcsFile(c, body)
+	case format == "json" && implementsJsonProvider(c):
+		return renderJson(c, body)
+	case format == "jsonld" && implementsJsonLdProvider(c):
+		return renderJsonLd(c, body)
+	case implementsContentProvider(c):
+		return c.(ContentProvider).Render(path)
+	case implementsMarkdownProvider(c):
+		return c.(MarkdownProvider).ToMarkdown(body...)
+	default:
+		panic("RenderPage: unsupported type")
 	}
-	if jsonLdProvider, ok := c.(JsonLdProvider); ok && format == "jsonld" {
-        return "```\n" + jsonLdProvider.ToJsonLD() + "\n```"
-    }
-	if contentProvider, ok := c.(ContentProvider); ok {
-        return contentProvider.Render(path)
-    }
-	if mdProvider, ok := c.(MarkdownProvider); ok {
-        return mdProvider.ToMarkdown(body...)
-    }
-    if obj, ok := c.(Component); ok {
-        return RenderComponent(path, obj)
-    }
-    panic("RenderPage: unsupported type")
 }
 
-func RenderComponent(path string, c Component) (out string) {
-	var sb strings.Builder
-
+func RenderComponent(path string, c Component) string {
 	if c == nil {
 		return ""
 	}
@@ -158,32 +131,24 @@ func RenderComponent(path string, c Component) (out string) {
 		panic("invalid path in RenderComponent: " + path)
 	}
 
+	var sb strings.Builder
 	switch u.Query().Get("format") {
 	case "json":
 		sb.WriteString("```json\n" + c.ToJson() + "\n```")
-	case "frame": // show same view as frame
+	case "frame":
 		sb.WriteString(c.ToJson())
 	default:
 		sb.WriteString(c.ToMarkdown())
 	}
 
-	dataURL := c.ToSvgDataUrl()
-	anchor := c.ToAnchor()
-	sb.WriteString("\n[![" + anchor + "](" + dataURL + ")](" + anchor + ")\n\n---\n\n")
-
+	sb.WriteString("\n[![" + c.ToAnchor() + "](" + c.ToSvgDataUrl() + ")](" + c.ToAnchor() + ")\n\n---\n\n")
 	return sb.String()
 }
 
+// Utility Functions
+
 func StringToAnchor(text string) string {
-	text = strings.ToLower(text)
-	text = strings.ReplaceAll(text, " ", "-")
-	text = strings.ReplaceAll(text, ".", "")
-	text = strings.ReplaceAll(text, ",", "")
-	text = strings.ReplaceAll(text, ":", "")
-	text = strings.ReplaceAll(text, ";", "")
-	text = strings.ReplaceAll(text, "!", "")
-	text = strings.ReplaceAll(text, "?", "")
-	return "#" + text
+	return "#" + slugify(text)
 }
 
 func SplitText(text string, maxLength int) []string {
@@ -204,42 +169,36 @@ func SplitText(text string, maxLength int) []string {
 }
 
 func SvgHeading(width, height string) string {
-	svg := "<svg width=\"" + width + "\" height=\"" + height + "\" xmlns=\"http://www.w3.org/2000/svg\">"
-	svg += "<style>"
-	svg += ".title { font: bold 24px sans-serif; }"
-	svg += ".subtitle { font: bold 18px sans-serif; }"
-	svg += ".sessiontitle { font: bold 16px sans-serif; }"
-	svg += ".text { font: 14px sans-serif; }"
-	svg += ".label { font: bold 14px sans-serif; }"
-	svg += ".speaker { font: 14px sans-serif; font-style: italic; }"
-	svg += ".session { font: 14px sans-serif; margin-top: 20px; }"
-	svg += "</style>"
-	return svg
+	return `<svg width="` + width + `" height="` + height + `" xmlns="http://www.w3.org/2000/svg">
+<style>
+.title { font: bold 24px sans-serif; }
+.subtitle { font: bold 18px sans-serif; }
+.sessiontitle { font: bold 16px sans-serif; }
+.text { font: 14px sans-serif; }
+.label { font: bold 14px sans-serif; }
+.speaker { font: 14px sans-serif; font-style: italic; }
+.session { font: 14px sans-serif; margin-top: 20px; }
+</style>`
 }
 
 func RenderSVGLine(y *int, class, label, text string) string {
 	var svg string
-	if label != "" && text != "" {
-		textLines := SplitText(text, 80)
+	textLines := SplitText(text, 80)
+	if label != "" && len(textLines) > 0 {
 		svg += ufmt.Sprintf(`<text x="20" y="%d" class="%s"><tspan class="label">%s</tspan> %s</text>`, *y, class, label, textLines[0])
 		*y += 20
-		for _, line := range textLines[1:] {
-			svg += ufmt.Sprintf(`<text x="20" y="%d" class="%s">%s</text>`, *y, class, line)
-			*y += 20
-		}
-	} else if text != "" {
-		textLines := SplitText(text, 80)
-		for _, line := range textLines {
-			svg += ufmt.Sprintf(`<text x="20" y="%d" class="%s">%s</text>`, *y, class, line)
-			*y += 20
-		}
+		textLines = textLines[1:]
+	}
+	for _, line := range textLines {
+		svg += ufmt.Sprintf(`<text x="20" y="%d" class="%s">%s</text>`, *y, class, line)
+		*y += 20
 	}
 	return svg
 }
 
 func FormatDuration(duration time.Duration) string {
 	d := strings.TrimRight(duration.String(), "0s")
-	if strings.HasSuffix(d, "h0m") { // e.g., "1h0m0s"
+	if strings.HasSuffix(d, "h0m") {
 		d = strings.TrimRight(d, "0m")
 	}
 	return d
@@ -270,15 +229,7 @@ func ParseDuration(d string) time.Duration {
 }
 
 func TagString(tag string) string {
-	tag = strings.ToLower(tag)
-	tag = strings.ReplaceAll(tag, " ", "-")
-	tag = strings.ReplaceAll(tag, ".", "")
-	tag = strings.ReplaceAll(tag, ",", "")
-	tag = strings.ReplaceAll(tag, ":", "")
-	tag = strings.ReplaceAll(tag, ";", "")
-	tag = strings.ReplaceAll(tag, "!", "")
-	tag = strings.ReplaceAll(tag, "?", "")
-	return tag
+	return slugify(tag)
 }
 
 func LinkTag(name string) string {
@@ -295,12 +246,17 @@ func ParseQuery(path string) url.Values {
 	return url.Values{}
 }
 
-func escapeHtml(s string) string {
-	s = strings.ReplaceAll(s, "&", "&amp;")
-	s = strings.ReplaceAll(s, "<", "&lt;")
-	s = strings.ReplaceAll(s, ">", "&gt;")
-	s = strings.ReplaceAll(s, "\"", "&quot;")
-	s = strings.ReplaceAll(s, "'", "&#39;")
+func EscapeHtml(s string) string {
+	replacements := map[string]string{
+		"&": "&amp;",
+		"<": "&lt;",
+		">": "&gt;",
+		"\"": "&quot;",
+		"'": "&#39;",
+	}
+	for old, new := range replacements {
+		s = strings.ReplaceAll(s, old, new)
+	}
 	return s
 }
 
@@ -309,13 +265,13 @@ func TxlinkButton(label, method string) string {
 }
 
 func Button(label, path string) string {
-	return SubmitButton(label, path, 16, 120) // Default font size and min width
+	return SubmitButton(label, path, 16, 120)
 }
 
 func SubmitButton(label, path string, fontSize, minWidth int) string {
-	charWidth := int(0.6 * float64(fontSize)) // Approximate width of each character
-	padding := 40                             // Total padding (left + right)
-	h := 2 * fontSize                         // Height of the button, 2x font size for padding
+	charWidth := int(0.6 * float64(fontSize))
+	padding := 40
+	h := 2 * fontSize
 	w := len(label)*charWidth + padding
 	if w < minWidth {
 		w = minWidth
@@ -325,30 +281,99 @@ func SubmitButton(label, path string, fontSize, minWidth int) string {
 <foreignObject x="16" y="-5" width="` + strconv.Itoa(w) + `" height="` + strconv.Itoa(h) + `">
   <body xmlns="http://www.w3.org/1999/xhtml">
     <button style="padding-left: 20px; font-size:` + strconv.Itoa(fontSize) + `px">
-      ` + escapeHtml(label) + `
+      ` + EscapeHtml(label) + `
     </button>
   </body>
 </foreignObject>
 </svg>`
 
 	dataUrl := "data:image/svg+xml;utf8," + url.PathEscape(svgButton)
-
 	return "[![" + label + "](" + dataUrl + ")](" + path + ")"
 }
 
-func ThumbnailSvg(link string, width, height int) string {
-	if !strings.HasPrefix("data:image/svg", link) {
-		panic("ThumbnailDataUrl requires a data URL") // NOTE: nesting external images is not supported
+func slugify(s string) string {
+	re := regexp.MustCompile(`[^a-z0-9]+`)
+	return strings.Trim(re.ReplaceAllString(strings.ToLower(s), "-"), "-")
+}
+
+func Pad3(s string) string {
+	for len(s) < 3 {
+		s = "0" + s
 	}
-	return `<svg xmlns="http://www.w3.org/2000/svg" width="` + strconv.Itoa(width) + `" height="` + strconv.Itoa(height) + `">
-        <image href="` + link + `" width="` + strconv.Itoa(width) + `" height="` + strconv.Itoa(height) + `"/>
-    </svg>`
+	return s
 }
 
-func ThumbnailDataUrl(link string, width, height int) string {
-	return "data:image/svg+xml;utf8," + url.PathEscape(ThumbnailSvg(link, width, height))
+func FormatDate(date time.Time) string {
+	if date.IsZero() {
+		return ""
+	}
+	return date.Format(DtFmt)
 }
 
-func ThumbnailLink(link string, width, height int) string {
-	return "![thumb](" + ThumbnailDataUrl(link, width, height) + ")"
+// Helper Functions
+
+func implementsIcsFileProvider(c interface{}) bool {
+    _, ok := c.(IcsFileProvider)
+    return ok
+}
+
+func implementsJsonProvider(c interface{}) bool {
+	_, ok := c.(JsonProvider)
+	return ok
+}
+
+func implementsJsonLdProvider(c interface{}) bool {
+	_, ok := c.(JsonLdProvider)
+	return ok
+}
+
+func implementsContentProvider(c interface{}) bool {
+	_, ok := c.(ContentProvider)
+	return ok
+}
+
+func implementsMarkdownProvider(c interface{}) bool {
+	_, ok := c.(MarkdownProvider)
+	return ok
+}
+
+func renderBody(body []Content) string {
+    var sb strings.Builder
+    for _, content := range body {
+        if content.Published {
+            sb.WriteString("\n\n" + content.Render() + "\n\n")
+            sb.WriteString("---\n\n")
+        }
+    }
+    return sb.String()
+}
+
+func renderIcsFile(c interface{}, body []Content) string {
+    var sb strings.Builder
+    sb.WriteString("```ics\n" + c.(IcsFileProvider).ToIcs() + "\n```")
+    sb.WriteString(renderBody(body))
+    return sb.String()
+}
+
+func renderJsonLD(c interface{}, body []Content) string {
+    var sb strings.Builder
+    sb.WriteString("```jsonld\n" + c.(JsonLdProvider).ToJsonLD() + "\n```")
+    sb.WriteString(renderBody(body))
+    return sb.String()
+}
+
+// Show data as Json next to the body content:w
+func renderJson(c interface{}, body []Content) string {
+	var sb strings.Builder
+	sb.WriteString("```\n\n" + c.(JsonProvider).ToJson() + "\n\n```")
+	sb.WriteString(renderBody(body))
+	return sb.String()
+}
+
+// Show JsonLD next to the body content
+func renderJsonLd(c interface{}, body []Content) string {
+	var sb strings.Builder
+	sb.WriteString("```\n" + c.(JsonLdProvider).ToJsonLD() + "\n```")
+	sb.WriteString(renderBody(body))
+	return sb.String()
 }

--- a/projects/gnoland/gno.land/p/eve000/event/component/component.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/component.gno
@@ -305,3 +305,20 @@ func SubmitButton(label, path string, fontSize, minWidth int) string {
 
 	return "[![" + label + "](" + dataUrl + ")](" + path + ")"
 }
+
+func ThumbnailSvg(link string, width, height int) string {
+	if !strings.HasPrefix("data:image/svg", link) {
+		panic("ThumbnailDataUrl requires a data URL") // NOTE: nesting external images is not supported
+	}
+	return `<svg xmlns="http://www.w3.org/2000/svg" width="` + strconv.Itoa(width) + `" height="` + strconv.Itoa(height) + `">
+        <image href="` + link + `" width="` + strconv.Itoa(width) + `" height="` + strconv.Itoa(height) + `"/>
+    </svg>`
+}
+
+func ThumbnailDataUrl(link string, width, height int) string {
+	return "data:image/svg+xml;utf8," + url.PathEscape(ThumbnailSvg(link, width, height))
+}
+
+func ThumbnailLink(link string, width, height int) string {
+	return "![thumb](" + ThumbnailDataUrl(link, width, height) + ")"
+}

--- a/projects/gnoland/gno.land/p/eve000/event/component/component.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/component.gno
@@ -14,15 +14,35 @@ import (
 // Interfaces
 
 type EventSchedule interface {
-	ToJson() string // schema.org compatible
+	Flyer() *Flyer
+	ToJson() string   // object representation of flyer
+	ToJsonLD() string // schema.org compatible event object
 	RenderMarkdown(body ...Content) string
 	RenderCalendar(string) string
-	Flyer() Component
+	// TODO: support more formats
+	// RenderFeed(string) string
+	// RenderFrame(string) string
 }
 
-type Page interface {
-	ToJson() string // schema.org compatible
-	RenderMarkdown(body ...Content) string
+// TODO: add a banner view suitable to nest in another realm
+type Banner interface {
+	RenderBanner(body ...Content) string
+}
+
+type ContentProvider interface {
+    Render(path ...string) string
+}
+
+type JsonLdProvider interface {
+	ToJsonLD() string // schema.org compatible
+}
+
+type JsonProvider interface {
+	ToJson() string
+}
+
+type MarkdownProvider interface {
+	ToMarkdown(...Content) string
 }
 
 type Component interface {
@@ -94,12 +114,12 @@ func (c *Content) Render(path ...string) string {
 
 // Functions
 
-func RenderPage(path string, c Page, body ...Content) string {
+func RenderPage(path string, c interface{}, body ...Content) string {
 	q := ParseQuery(path)
 	format := q.Get("format")
-	if format == "json" {
+	if jsonProvider, ok := c.(JsonProvider); ok  && format == "json" {
 		var sb strings.Builder
-		sb.WriteString("```\n\n" + c.ToJson() + "\n\n```")
+		sb.WriteString("```\n\n" + jsonProvider.ToJson() + "\n\n```")
 		if len(body) > 0 {
 			sb.WriteString("\n\n---\n\n")
 		}
@@ -111,7 +131,19 @@ func RenderPage(path string, c Page, body ...Content) string {
 		}
 		return sb.String()
 	}
-	return c.RenderMarkdown(body...)
+	if jsonLdProvider, ok := c.(JsonLdProvider); ok && format == "jsonld" {
+        return "```\n" + jsonLdProvider.ToJsonLD() + "\n```"
+    }
+	if contentProvider, ok := c.(ContentProvider); ok {
+        return contentProvider.Render(path)
+    }
+	if mdProvider, ok := c.(MarkdownProvider); ok {
+        return mdProvider.ToMarkdown(body...)
+    }
+    if obj, ok := c.(Component); ok {
+        return RenderComponent(path, obj)
+    }
+    panic("RenderPage: unsupported type")
 }
 
 func RenderComponent(path string, c Component) (out string) {
@@ -135,11 +167,9 @@ func RenderComponent(path string, c Component) (out string) {
 		sb.WriteString(c.ToMarkdown())
 	}
 
-	if _, ok := c.RenderOpts()["Svg"]; ok {
-		dataURL := c.ToSvgDataUrl()
-		anchor := c.ToAnchor()
-		sb.WriteString("\n[![" + anchor + "](" + dataURL + ")](" + anchor + ")\n\n---\n\n")
-	}
+	dataURL := c.ToSvgDataUrl()
+	anchor := c.ToAnchor()
+	sb.WriteString("\n[![" + anchor + "](" + dataURL + ")](" + anchor + ")\n\n---\n\n")
 
 	return sb.String()
 }

--- a/projects/gnoland/gno.land/p/eve000/event/component/flyer.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/flyer.gno
@@ -1,15 +1,14 @@
 package component
 
 import (
-	"net/url"
-	"regexp"
 	"std"
-	"strconv"
 	"strings"
 	"time"
+	"net/url"
 
 	"gno.land/p/demo/ufmt"
 )
+
 
 type Flyer struct {
 	Name           string
@@ -25,13 +24,6 @@ type Flyer struct {
 }
 
 var _ Component = (*Flyer)(nil)
-
-func FormatDate(date time.Time) string {
-	if date.IsZero() {
-		return ""
-	}
-	return date.Format(DtFmt)
-}
 
 func (a *Flyer) ToAnchor() string {
 	return StringToAnchor(a.Name)
@@ -57,13 +49,13 @@ func (a *Flyer) ToMarkdown(body ...Content) string {
 	fullURL := std.CurrentRealm().PkgPath()
 
 	if calHost, ok := a.RenderOpts()["CalendarHost"]; ok {
-		markdown += "[➕📅 Add to Calendar](" + calHost.(string) + "/" + fullURL + "?format=ics" + ")\n\n"
+		markdown += "[➕📅 Subscribe to Calendar](" + calHost.(string) + "/" + fullURL + "?format=ics" + ")\n\n"
 	}
 	if calFile, ok := a.RenderOpts()["CalendarFile"]; ok {
 		markdown += "[📥 Download Calendar File](" + calFile.(string) + "/" + fullURL + "?format=ics" + ")\n\n"
 	}
 	if _, ok := a.RenderOpts()["CalendarDataUrl"]; ok {
-		markdown += "[📅 Calendar Data URL](" + a.CalenderDataUrl() + ")\n\n"
+		markdown += "[📅 Add To Calendar](" + CalenderDataUrl("?format=ics", a) + ")\n\n"
 	}
 
 	if len(body) > 0 {
@@ -124,6 +116,7 @@ func (a *Flyer) ToMarkdown(body ...Content) string {
 
 	return markdown
 }
+//REVIEW: do we still want ToJsonLD signature on this object?
 
 func (a *Flyer) ToJson() string {
 	json := "{\n"
@@ -195,153 +188,10 @@ func (a *Flyer) SetRenderOpts(opts map[string]interface{}) {
 	a.renderOpts = opts
 }
 
-func (a *Flyer) CalenderDataUrl() string {
-	data := a.RenderCalendar("?format=ics")
-	return "data:text/calendar;charset=utf-8," + url.QueryEscape(data)
-}
-
-const DateFormatJsonLD = "2006-01-02T15:04:05-07:00"
-
 func (a *Flyer) ToJsonLD() string {
-	var sb strings.Builder
-	sb.WriteString(`{
-        "@context": "https://schema.org",
-        "@type": "Event",
-        "name": "` + ufmt.Sprintf("%s", a.Name) + `",`)
-
-	if a.Status == EventPostponed {
-		sb.WriteString(`
-        "previousStartDate": "` + ufmt.Sprintf("%s", a.StartDate.Format(DateFormatJsonLD)) + `",`)
-	} else {
-		sb.WriteString(`
-        "startDate": "` + ufmt.Sprintf("%s", a.StartDate.Format(DateFormatJsonLD)) + `",`)
-		sb.WriteString(`
-        "endDate": "` + ufmt.Sprintf("%s", a.EndDate.Format(DateFormatJsonLD)) + `",`)
-	}
-
-	sb.WriteString(`
-        "eventAttendanceMode": "` + ufmt.Sprintf("%s", a.AttendanceMode) + `",
-        "eventStatus": "` + ufmt.Sprintf("%s", a.Status) + `",`)
-
-	if a.AttendanceMode != OfflineEventAttendanceMode && a.Location != nil {
-		sb.WriteString(`
-        "location": {
-            "@type": "Place",
-            "name": "` + ufmt.Sprintf("%s", a.Location.Name) + `"
-        },`)
-	}
-
-	// Add images if available
-	sb.WriteString(`
-        "image": [`)
-	for i, img := range a.Images {
-		if i > 0 {
-			sb.WriteString(",")
-		}
-		sb.WriteString(`"` + ufmt.Sprintf("%s", img) + `"`)
-	}
-	sb.WriteString(`],`)
-
-	sb.WriteString(`
-        "description": "` + ufmt.Sprintf("%s", a.Description) + `"
-    }`)
-	return sb.String()
+    return EventJsonLD("?format=jsonld", a)
 }
 
-func (a *Flyer) RenderCalendar(path string) string {
-	var f = ufmt.Sprintf
-	var b strings.Builder
-	w := func(s string) {
-		b.WriteString(s + "\n")
-	}
-
-	q := ParseQuery(path)
-	sessionIDs := q["session"]
-	format := strings.ToLower(q.Get("format"))
-
-	useAll := len(sessionIDs) == 0
-	allowed := make(map[string]bool)
-	for _, id := range sessionIDs {
-		allowed[id] = true
-	}
-	include := func(id string) bool { return useAll || allowed[id] }
-
-	switch format {
-	case "json":
-		b.WriteString(a.ToJson())
-		return b.String()
-
-	case "ics":
-		w("BEGIN:VCALENDAR")
-		w("VERSION:2.0")
-		w("CALSCALE:GREGORIAN")
-		w("PRODID:-//gno.land//Launch Calendar//EN")
-		w("METHOD:PUBLISH\n")
-
-		w("BEGIN:VEVENT")
-		w(f("UID:event-%s@%s", slugify(a.Name), "gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar"))
-		w("SEQUENCE:0")
-		w(f("DTSTAMP:%s", time.Now().UTC().Format("20060102T150405Z")))
-		w(f("DTSTART;VALUE=DATE:%s", a.StartDate.Format("20060102")))
-		w(f("DTEND;VALUE=DATE:%s", a.StartDate.AddDate(0, 0, 1).Format("20060102"))) // 👈 Fix: DTEND is exclusive
-		w(f("SUMMARY:%s", a.Name))
-		w(f("DESCRIPTION:%s", a.Description))
-		if a.Location != nil && a.Location.Name != "" {
-			w(f("LOCATION:%s", a.Location.Name))
-		}
-		w("END:VEVENT\n")
-
-		for i, s := range a.Sessions {
-			id := Pad3(strconv.Itoa(i))
-			if !include(id) {
-				continue
-			}
-
-			w("BEGIN:VEVENT")
-			w(f("UID:%s-%d@%s",
-				slugify(s.Title)[:5],
-				s.StartTime.Unix(),
-				"gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar",
-			))
-			w(f("SEQUENCE:%d", s.Sequence))
-			w(f("DTSTAMP:%s", time.Now().UTC().Format("20060102T150405Z")))
-			w(f("DTSTART:%s", s.StartTime.UTC().Format("20060102T150000Z")))
-			w(f("DTEND:%s", s.EndTime.UTC().Format("20060102T150000Z")))
-			w(f("SUMMARY:%s", s.Title))
-			w(f("DESCRIPTION:%s", s.Description))
-			w(f("LOCATION:%s", s.Location.Name))
-			if s.Cancelled {
-				w("STATUS:CANCELLED")
-			}
-			w("END:VEVENT\n")
-		}
-
-		w("END:VCALENDAR")
-		return b.String()
-
-	default:
-		w(f("# %s\n\n%s", a.Name, a.Description))
-		for i, s := range a.Sessions {
-			id := Pad3(strconv.Itoa(i))
-			if !include(id) {
-				continue
-			}
-			w(s.ToMarkdown())
-		}
-		return b.String()
-	}
-}
-
-func slugify(s string) string {
-	re := regexp.MustCompile(`[^a-z0-9]+`)
-	lower := strings.ToLower(s)
-	slug := re.ReplaceAllString(lower, "-")
-	return strings.Trim(slug, "-")
-}
-
-func Pad3(s string) string {
-	for len(s) < 3 {
-		s = "0" + s
-	}
-	return s
+func (a *Flyer) ToIcs() string {
+    return IcsCalendarFile("?format=ics", a)
 }

--- a/projects/gnoland/gno.land/p/eve000/event/component/flyer.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/flyer.gno
@@ -2,7 +2,9 @@ package component
 
 import (
 	"net/url"
+	"regexp"
 	"std"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +20,7 @@ type Flyer struct {
 	AttendanceMode EventAttendanceMode
 	Description    string
 	Sessions       []*Session
+	Images         []string
 	renderOpts     map[string]interface{}
 }
 
@@ -51,10 +54,16 @@ func (a *Flyer) ToMarkdown(body ...Content) string {
 	}
 
 	markdown += a.Description + "\n\n"
+	fullURL := std.CurrentRealm().PkgPath()
 
 	if calHost, ok := a.RenderOpts()["CalendarHost"]; ok {
-		fullURL := std.CurrentRealm().PkgPath() + "?format=ics"
-		markdown += "[➕📅 Add to Calendar](" + calHost.(string) + "/" + fullURL + ")\n\n"
+		markdown += "[➕📅 Add to Calendar](" + calHost.(string) + "/" + fullURL + "?format=ics" + ")\n\n"
+	}
+	if calFile, ok := a.RenderOpts()["CalendarFile"]; ok {
+		markdown += "[📥 Download Calendar File](" + calFile.(string) + "/" + fullURL + "?format=ics" + ")\n\n"
+	}
+	if _, ok := a.RenderOpts()["CalendarDataUrl"]; ok {
+		markdown += "[📅 Calendar Data URL](" + a.CalenderDataUrl() + ")\n\n"
 	}
 
 	if len(body) > 0 {
@@ -109,6 +118,9 @@ func (a *Flyer) ToMarkdown(body ...Content) string {
 	if _, ok := a.RenderOpts()["Location"]; ok {
 		markdown += "## Locations\n\n" + locationsMarkdown
 	}
+	if _, ok := a.RenderOpts()["SvgFooter"]; ok {
+		markdown += "[![Flyer SVG](" + a.ToSvgDataUrl() + ")](" + a.ToAnchor() + ")\n\n"
+	}
 
 	return markdown
 }
@@ -116,7 +128,9 @@ func (a *Flyer) ToMarkdown(body ...Content) string {
 func (a *Flyer) ToJson() string {
 	json := "{\n"
 	json += "\"Name\":\"" + a.Name + "\",\n"
-	json += "\"Location\":" + a.Location.ToJson() + ",\n"
+	if a.Location != nil && a.Location.Name != "" {
+		json += "\"Location\":" + a.Location.ToJson() + ",\n"
+	}
 	json += "\"StartDate\":\"" + FormatDate(a.StartDate) + "\",\n"
 	json += "\"EndDate\":\"" + FormatDate(a.EndDate) + "\",\n"
 	json += "\"Description\":\"" + a.Description + "\",\n"
@@ -142,7 +156,9 @@ func (a *Flyer) ToSVGFragment(y *int) string {
 	svg := "<rect width=\"100%\" height=\"100%\" fill=\"#eeeeee\" rx=\"15\"/>"
 	svg += RenderSVGLine(y, "title", "", a.Name)
 	*y += 10
-	svg += RenderSVGLine(y, "subtitle", "", a.Location.Name)
+	if _, ok := a.RenderOpts()["Location"]; ok && a.Location != nil {
+		svg += RenderSVGLine(y, "subtitle", "", a.Location.Name)
+	}
 	*y += 10
 	if a.Status == EventCancelled {
 		svg += RenderSVGLine(y, "text", "label", "Status: Canceled")
@@ -177,4 +193,155 @@ func (a *Flyer) RenderOpts() map[string]interface{} {
 
 func (a *Flyer) SetRenderOpts(opts map[string]interface{}) {
 	a.renderOpts = opts
+}
+
+func (a *Flyer) CalenderDataUrl() string {
+	data := a.RenderCalendar("?format=ics")
+	return "data:text/calendar;charset=utf-8," + url.QueryEscape(data)
+}
+
+const DateFormatJsonLD = "2006-01-02T15:04:05-07:00"
+
+func (a *Flyer) ToJsonLD() string {
+	var sb strings.Builder
+	sb.WriteString(`{
+        "@context": "https://schema.org",
+        "@type": "Event",
+        "name": "` + ufmt.Sprintf("%s", a.Name) + `",`)
+
+	if a.Status == EventPostponed {
+		sb.WriteString(`
+        "previousStartDate": "` + ufmt.Sprintf("%s", a.StartDate.Format(DateFormatJsonLD)) + `",`)
+	} else {
+		sb.WriteString(`
+        "startDate": "` + ufmt.Sprintf("%s", a.StartDate.Format(DateFormatJsonLD)) + `",`)
+		sb.WriteString(`
+        "endDate": "` + ufmt.Sprintf("%s", a.EndDate.Format(DateFormatJsonLD)) + `",`)
+	}
+
+	sb.WriteString(`
+        "eventAttendanceMode": "` + ufmt.Sprintf("%s", a.AttendanceMode) + `",
+        "eventStatus": "` + ufmt.Sprintf("%s", a.Status) + `",`)
+
+	if a.AttendanceMode != OfflineEventAttendanceMode && a.Location != nil {
+		sb.WriteString(`
+        "location": {
+            "@type": "Place",
+            "name": "` + ufmt.Sprintf("%s", a.Location.Name) + `"
+        },`)
+	}
+
+	// Add images if available
+	sb.WriteString(`
+        "image": [`)
+	for i, img := range a.Images {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`"` + ufmt.Sprintf("%s", img) + `"`)
+	}
+	sb.WriteString(`],`)
+
+	sb.WriteString(`
+        "description": "` + ufmt.Sprintf("%s", a.Description) + `"
+    }`)
+	return sb.String()
+}
+
+func (a *Flyer) RenderCalendar(path string) string {
+	var f = ufmt.Sprintf
+	var b strings.Builder
+	w := func(s string) {
+		b.WriteString(s + "\n")
+	}
+
+	q := ParseQuery(path)
+	sessionIDs := q["session"]
+	format := strings.ToLower(q.Get("format"))
+
+	useAll := len(sessionIDs) == 0
+	allowed := make(map[string]bool)
+	for _, id := range sessionIDs {
+		allowed[id] = true
+	}
+	include := func(id string) bool { return useAll || allowed[id] }
+
+	switch format {
+	case "json":
+		b.WriteString(a.ToJson())
+		return b.String()
+
+	case "ics":
+		w("BEGIN:VCALENDAR")
+		w("VERSION:2.0")
+		w("CALSCALE:GREGORIAN")
+		w("PRODID:-//gno.land//Launch Calendar//EN")
+		w("METHOD:PUBLISH\n")
+
+		w("BEGIN:VEVENT")
+		w(f("UID:event-%s@%s", slugify(a.Name), "gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar"))
+		w("SEQUENCE:0")
+		w(f("DTSTAMP:%s", time.Now().UTC().Format("20060102T150405Z")))
+		w(f("DTSTART;VALUE=DATE:%s", a.StartDate.Format("20060102")))
+		w(f("DTEND;VALUE=DATE:%s", a.StartDate.AddDate(0, 0, 1).Format("20060102"))) // 👈 Fix: DTEND is exclusive
+		w(f("SUMMARY:%s", a.Name))
+		w(f("DESCRIPTION:%s", a.Description))
+		if a.Location != nil && a.Location.Name != "" {
+			w(f("LOCATION:%s", a.Location.Name))
+		}
+		w("END:VEVENT\n")
+
+		for i, s := range a.Sessions {
+			id := Pad3(strconv.Itoa(i))
+			if !include(id) {
+				continue
+			}
+
+			w("BEGIN:VEVENT")
+			w(f("UID:%s-%d@%s",
+				slugify(s.Title)[:5],
+				s.StartTime.Unix(),
+				"gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar",
+			))
+			w(f("SEQUENCE:%d", s.Sequence))
+			w(f("DTSTAMP:%s", time.Now().UTC().Format("20060102T150405Z")))
+			w(f("DTSTART:%s", s.StartTime.UTC().Format("20060102T150000Z")))
+			w(f("DTEND:%s", s.EndTime.UTC().Format("20060102T150000Z")))
+			w(f("SUMMARY:%s", s.Title))
+			w(f("DESCRIPTION:%s", s.Description))
+			w(f("LOCATION:%s", s.Location.Name))
+			if s.Cancelled {
+				w("STATUS:CANCELLED")
+			}
+			w("END:VEVENT\n")
+		}
+
+		w("END:VCALENDAR")
+		return b.String()
+
+	default:
+		w(f("# %s\n\n%s", a.Name, a.Description))
+		for i, s := range a.Sessions {
+			id := Pad3(strconv.Itoa(i))
+			if !include(id) {
+				continue
+			}
+			w(s.ToMarkdown())
+		}
+		return b.String()
+	}
+}
+
+func slugify(s string) string {
+	re := regexp.MustCompile(`[^a-z0-9]+`)
+	lower := strings.ToLower(s)
+	slug := re.ReplaceAllString(lower, "-")
+	return strings.Trim(slug, "-")
+}
+
+func Pad3(s string) string {
+	for len(s) < 3 {
+		s = "0" + s
+	}
+	return s
 }

--- a/projects/gnoland/gno.land/p/eve000/event/component/jsonld.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/jsonld.gno
@@ -1,0 +1,55 @@
+package component
+
+import (
+    "strings"
+
+    "gno.land/p/demo/ufmt"
+)
+
+const DateFormatJsonLD = "2006-01-02T15:04:05-07:00"
+
+func EventJsonLD(_ string, a *Flyer) string {
+	var sb strings.Builder
+	sb.WriteString(`{
+        "@context": "https://schema.org",
+        "@type": "Event",
+        "name": "` + ufmt.Sprintf("%s", a.Name) + `",`)
+
+	if a.Status == EventPostponed {
+		sb.WriteString(`
+        "previousStartDate": "` + ufmt.Sprintf("%s", a.StartDate.Format(DateFormatJsonLD)) + `",`)
+	} else {
+		sb.WriteString(`
+        "startDate": "` + ufmt.Sprintf("%s", a.StartDate.Format(DateFormatJsonLD)) + `",`)
+		sb.WriteString(`
+        "endDate": "` + ufmt.Sprintf("%s", a.EndDate.Format(DateFormatJsonLD)) + `",`)
+	}
+
+	sb.WriteString(`
+        "eventAttendanceMode": "` + ufmt.Sprintf("%s", a.AttendanceMode) + `",
+        "eventStatus": "` + ufmt.Sprintf("%s", a.Status) + `",`)
+
+	if a.AttendanceMode != OfflineEventAttendanceMode && a.Location != nil {
+		sb.WriteString(`
+        "location": {
+            "@type": "Place",
+            "name": "` + ufmt.Sprintf("%s", a.Location.Name) + `"
+        },`)
+	}
+
+	// Add images if available
+	sb.WriteString(`
+        "image": [`)
+	for i, img := range a.Images {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`"` + ufmt.Sprintf("%s", img) + `"`)
+	}
+	sb.WriteString(`],`)
+
+	sb.WriteString(`
+        "description": "` + ufmt.Sprintf("%s", a.Description) + `"
+    }`)
+	return sb.String()
+}

--- a/projects/gnoland/gno.land/p/eve000/event/component/session.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/session.gno
@@ -108,8 +108,10 @@ func (s *Session) ToSVGFragment(y *int) string {
 
 	// Left column (speaker, times, location)
 	leftY := *y
-	svg += ufmt.Sprintf(`<text x="20" y="%d" class="speaker">Speaker: %s</text>`, leftY, s.Speaker.Name)
-	leftY += 20
+	if _, ok := s.RenderOpts()["Speaker"]; ok && s.Speaker != nil && s.Speaker.Name != "" {
+		svg += ufmt.Sprintf(`<text x="20" y="%d" class="speaker">Speaker: %s</text>`, leftY, s.Speaker.Name)
+		leftY += 20
+	}
 	svg += ufmt.Sprintf(`<text x="20" y="%d" class="text">Start Time: %s</text>`, leftY, s.StartTime.Format(time.Kitchen))
 	leftY += 20
 	svg += ufmt.Sprintf(`<text x="20" y="%d" class="text">End Time: %s</text>`, leftY, s.EndTime.Format(time.Kitchen))

--- a/projects/gnoland/gno.land/p/eve000/event/component/session.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/session.gno
@@ -19,9 +19,7 @@ type Session struct {
 	Cancelled   bool
 }
 
-var (
-	_ Component = (*Session)(nil)
-)
+var _ Component = (*Session)(nil)
 
 func (s *Session) SetTitle(title string) {
 	s.Title = title

--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -48,8 +48,6 @@ type Api interface {
 	UnsetRoleHandler(role string)
 }
 
-var f = ufmt.Sprintf
-
 type Storage struct {
 	Sessions  *avl.Tree
 	Speakers  *avl.Tree
@@ -165,7 +163,7 @@ func (evt *Event) GetSessions() []*component.Session {
 	return sessions
 }
 func (evt *Event) Flyer() component.Component {
-	f := &component.Flyer{
+	flyer := &component.Flyer{
 		Name:        evt.Name,
 		Location:    evt.Location,
 		StartDate:   evt.StartDate,
@@ -174,8 +172,8 @@ func (evt *Event) Flyer() component.Component {
 		Description: evt.Description,
 		Sessions:    evt.Sessions,
 	}
-	f.SetRenderOpts(evt.renderOpts)
-	return f
+	flyer.SetRenderOpts(evt.renderOpts)
+	return flyer
 }
 
 func (evt *Event) RenderMarkdown(body ...component.Content) string {
@@ -183,8 +181,11 @@ func (evt *Event) RenderMarkdown(body ...component.Content) string {
 }
 
 func (evt *Event) RenderCalendar(path string) string {
+	var f = ufmt.Sprintf
 	var b strings.Builder
-	w := makeWriter(&b)
+	w := func(s string) {
+		b.WriteString(s + "\n")
+	}
 
 	q := component.ParseQuery(path)
 	sessionIDs := q["session"]
@@ -260,12 +261,6 @@ func (evt *Event) RenderCalendar(path string) string {
 			w(s.ToMarkdown())
 		}
 		return b.String()
-	}
-}
-
-func makeWriter(b *strings.Builder) func(string) {
-	return func(s string) {
-		b.WriteString(s + "\n")
 	}
 }
 

--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -1,19 +1,14 @@
 package event
 
 import (
-	"regexp"
 	"std"
 	"strconv"
-	"strings"
 	"time"
 
 	"gno.land/p/demo/avl"
-	"gno.land/p/demo/ufmt"
 	"gno.land/p/eve000/event/component"
 )
 
-var _ component.EventSchedule = (*Event)(nil)
-var _ component.Page = (*Event)(nil)
 
 // FIXME either change interface or satisfy it
 //var _ Api = (*Event)(nil)
@@ -99,7 +94,7 @@ func (evt *Event) AddSpeaker(s *component.Speaker) {
 	if evt.storage.Speakers == nil {
 		evt.storage.Speakers = &avl.Tree{}
 	}
-	id := Pad3(strconv.Itoa(evt.storage.Speakers.Size()))
+	id := component.Pad3(strconv.Itoa(evt.storage.Speakers.Size()))
 	evt.storage.Speakers.Set(AvlKey("speaker", id), s)
 }
 
@@ -110,7 +105,7 @@ func (evt *Event) AddLocation(loc *component.Location) {
 	if evt.storage.Locations == nil {
 		evt.storage.Locations = &avl.Tree{}
 	}
-	id := Pad3(strconv.Itoa(evt.storage.Locations.Size()))
+	id := component.Pad3(strconv.Itoa(evt.storage.Locations.Size()))
 	evt.storage.Locations.Set(AvlKey("location", id), loc)
 }
 
@@ -122,7 +117,7 @@ func (evt *Event) AddSession(sess *component.Session) {
 		evt.storage.Sessions = &avl.Tree{}
 	}
 	// TODO: maybe Pad3 can accept interface so extras stringconv isn't needed here
-	id := Pad3(strconv.Itoa(evt.storage.Sessions.Size()))
+	id := component.Pad3(strconv.Itoa(evt.storage.Sessions.Size()))
 	evt.storage.Sessions.Set(AvlKey("session", id), sess)
 }
 
@@ -162,7 +157,7 @@ func (evt *Event) GetSessions() []*component.Session {
 	})
 	return sessions
 }
-func (evt *Event) Flyer() component.Component {
+func (evt *Event) Flyer() *component.Flyer {
 	flyer := &component.Flyer{
 		Name:        evt.Name,
 		Location:    evt.Location,
@@ -171,116 +166,15 @@ func (evt *Event) Flyer() component.Component {
 		Status:      evt.Status,
 		Description: evt.Description,
 		Sessions:    evt.Sessions,
+		Images:    evt.Images,
 	}
 	flyer.SetRenderOpts(evt.renderOpts)
 	return flyer
 }
 
-func (evt *Event) RenderMarkdown(body ...component.Content) string {
-	return evt.Flyer().ToMarkdown(body...)
-}
-
-func (evt *Event) RenderCalendar(path string) string {
-	var f = ufmt.Sprintf
-	var b strings.Builder
-	w := func(s string) {
-		b.WriteString(s + "\n")
-	}
-
-	q := component.ParseQuery(path)
-	sessionIDs := q["session"]
-	format := strings.ToLower(q.Get("format"))
-
-	useAll := len(sessionIDs) == 0
-	allowed := make(map[string]bool)
-	for _, id := range sessionIDs {
-		allowed[id] = true
-	}
-	include := func(id string) bool { return useAll || allowed[id] }
-
-	sessions := evt.GetSessions()
-
-	switch format {
-	case "json":
-		b.WriteString(evt.Flyer().ToJson())
-		return b.String()
-
-	case "ics":
-		w("BEGIN:VCALENDAR")
-		w("VERSION:2.0")
-		w("CALSCALE:GREGORIAN")
-		w("PRODID:-//gno.land//Launch Calendar//EN")
-		w("METHOD:PUBLISH\n")
-
-		w("BEGIN:VEVENT")
-		w(f("UID:event-%s@%s", slugify(evt.Name), "gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar"))
-		w("SEQUENCE:0")
-		w(f("DTSTAMP:%s", time.Now().UTC().Format("20060102T150405Z")))
-		w(f("DTSTART;VALUE=DATE:%s", evt.StartDate.Format("20060102")))
-		w(f("DTEND;VALUE=DATE:%s", evt.StartDate.AddDate(0, 0, 1).Format("20060102"))) // 👈 Fix: DTEND is exclusive
-		w(f("SUMMARY:%s", evt.Name))
-		w(f("DESCRIPTION:%s", evt.Description))
-		w(f("LOCATION:%s", evt.Location.Name))
-		w("END:VEVENT\n")
-
-		for i, s := range sessions {
-			id := Pad3(strconv.Itoa(i))
-			if !include(id) {
-				continue
-			}
-
-			w("BEGIN:VEVENT")
-			w(f("UID:%s-%d@%s",
-				slugify(s.Title)[:5],
-				s.StartTime.Unix(),
-				"gno.land/r/buidlthefuture000/events/gnolandlaunch/calendar",
-			))
-			w(f("SEQUENCE:%d", s.Sequence))
-			w(f("DTSTAMP:%s", time.Now().UTC().Format("20060102T150405Z")))
-			w(f("DTSTART:%s", s.StartTime.UTC().Format("20060102T150000Z")))
-			w(f("DTEND:%s", s.EndTime.UTC().Format("20060102T150000Z")))
-			w(f("SUMMARY:%s", s.Title))
-			w(f("DESCRIPTION:%s", s.Description))
-			w(f("LOCATION:%s", s.Location.Name))
-			if s.Cancelled {
-				w("STATUS:CANCELLED")
-			}
-			w("END:VEVENT\n")
-		}
-
-		w("END:VCALENDAR")
-		return b.String()
-
-	default:
-		w(f("# %s\n\n%s", evt.Name, evt.Description))
-		for i, s := range sessions {
-			id := Pad3(strconv.Itoa(i))
-			if !include(id) {
-				continue
-			}
-			w(s.ToMarkdown())
-		}
-		return b.String()
-	}
-}
-
-func slugify(s string) string {
-	re := regexp.MustCompile(`[^a-z0-9]+`)
-	lower := strings.ToLower(s)
-	slug := re.ReplaceAllString(lower, "-")
-	return strings.Trim(slug, "-")
-}
-
-func Pad3(s string) string {
-	for len(s) < 3 {
-		s = "0" + s
-	}
-	return s
-}
-
 // build a key for the AVL tree like "event:123" "speaker:456" or "location:789"
 func AvlKey(label string, id string) string {
-	return Pad3(id)
+	return component.Pad3(id)
 }
 
 // Event may not be a component (yet!) but it is where the render opts are stored.
@@ -296,50 +190,3 @@ func (evt *Event) ToAnchor() string {
 	return component.StringToAnchor(evt.Name)
 }
 
-const DateFormatJsonLD = "2006-01-02T15:04:05-07:00"
-
-func (evt *Event) ToJson() string {
-	var sb strings.Builder
-	sb.WriteString(`{
-        "@context": "https://schema.org",
-        "@type": "Event",
-        "name": "` + ufmt.Sprintf("%s", evt.Name) + `",`)
-
-	if evt.Status == component.EventPostponed {
-		sb.WriteString(`
-        "previousStartDate": "` + ufmt.Sprintf("%s", evt.StartDate.Format(DateFormatJsonLD)) + `",`)
-	} else {
-		sb.WriteString(`
-        "startDate": "` + ufmt.Sprintf("%s", evt.StartDate.Format(DateFormatJsonLD)) + `",`)
-		sb.WriteString(`
-        "endDate": "` + ufmt.Sprintf("%s", evt.EndDate.Format(DateFormatJsonLD)) + `",`)
-	}
-
-	sb.WriteString(`
-        "eventAttendanceMode": "` + ufmt.Sprintf("%s", evt.AttendanceMode) + `",
-        "eventStatus": "` + ufmt.Sprintf("%s", evt.Status) + `",`)
-
-	if evt.AttendanceMode != component.OfflineEventAttendanceMode && evt.Location != nil {
-		sb.WriteString(`
-        "location": {
-            "@type": "Place",
-            "name": "` + ufmt.Sprintf("%s", evt.Location.Name) + `"
-        },`)
-	}
-
-	// Add images if available
-	sb.WriteString(`
-        "image": [`)
-	for i, img := range evt.Images {
-		if i > 0 {
-			sb.WriteString(",")
-		}
-		sb.WriteString(`"` + ufmt.Sprintf("%s", img) + `"`)
-	}
-	sb.WriteString(`],`)
-
-	sb.WriteString(`
-        "description": "` + ufmt.Sprintf("%s", evt.Description) + `"
-    }`)
-	return sb.String()
-}

--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -49,6 +49,9 @@ type Storage struct {
 	Locations *avl.Tree
 }
 
+// REVIEW: Event / Flyer are duals of each other.
+// we return Flyer objects to non-admin users - (lacking any edit methods)
+// the event object is protected for edits only by patching from specific 'sub-realms'
 type Event struct {
 	Name           string
 	Location       *component.Location
@@ -145,6 +148,7 @@ func (evt *Event) GetSession(id string) *component.Session {
 	return s.(*component.Session)
 }
 
+// REVIEW: is this used?
 func (evt *Event) GetSessions() []*component.Session {
 	if evt.storage == nil || evt.storage.Sessions == nil {
 		return nil
@@ -189,4 +193,10 @@ func (evt *Event) SetRenderOpts(opts map[string]interface{}) {
 func (evt *Event) ToAnchor() string {
 	return component.StringToAnchor(evt.Name)
 }
+
+// Render provides a syntactic sugar for rendering a Flyer using a template function.
+func (evt *Event) Render(path string, tpl func(path string, flyer *component.Flyer) string) string {
+    return tpl(path, evt.Flyer())
+}
+
 

--- a/projects/gnoland/gno.land/p/eve000/event/registry.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/registry.gno
@@ -48,7 +48,6 @@ func (r *Registry) Render(path string, body ...component.Content) string {
 	}
 	evt := r.GetEvent(event_id)
 	format := q.Get("format")
-	view := q.Get("view")
 	switch {
 	case hasQueryParam(q, "session"):
 		return component.RenderComponent(path, evt.GetSession(q.Get("session")))
@@ -56,12 +55,10 @@ func (r *Registry) Render(path string, body ...component.Content) string {
 		return component.RenderComponent(path, evt.GetLocation(q.Get("location")))
 	case hasQueryParam(q, "speaker"):
 		return component.RenderComponent(path, evt.GetSpeaker(q.Get("speaker")))
-	case view == "flyer":
-		return component.RenderComponent(path, evt.Flyer())
-	case view == "calendar" || format == "ics":
-		return "```\n" + evt.RenderCalendar(path) + "\n```"
+	case format == "ics":
+		return "```\n" + evt.Flyer().RenderCalendar(path) + "\n```"
 	default:
-		return component.RenderPage(path, evt, body...)
+		return component.RenderPage(path, evt.Flyer(), body...)
 	}
 }
 
@@ -120,7 +117,7 @@ func (r *Registry) RegisterEvent(e *Event, opts map[string]interface{}) string {
 		e.AddLocation(s.Location)
 	}
 
-	id := Pad3(strconv.Itoa(r.Events.Size())) // 001, 002, etc.
+	id := component.Pad3(strconv.Itoa(r.Events.Size())) // 001, 002, etc.
 	r.Events.Set(id, e)
 	return id
 }

--- a/projects/gnoland/gno.land/p/eve000/event/registry.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/registry.gno
@@ -47,7 +47,6 @@ func (r *Registry) Render(path string, body ...component.Content) string {
 		event_id = r.LiveEventId
 	}
 	evt := r.GetEvent(event_id)
-	format := q.Get("format")
 	switch {
 	case hasQueryParam(q, "session"):
 		return component.RenderComponent(path, evt.GetSession(q.Get("session")))
@@ -55,8 +54,6 @@ func (r *Registry) Render(path string, body ...component.Content) string {
 		return component.RenderComponent(path, evt.GetLocation(q.Get("location")))
 	case hasQueryParam(q, "speaker"):
 		return component.RenderComponent(path, evt.GetSpeaker(q.Get("speaker")))
-	case format == "ics":
-		return "```\n" + evt.Flyer().RenderCalendar(path) + "\n```"
 	default:
 		return component.RenderPage(path, evt.Flyer(), body...)
 	}

--- a/projects/gnoland/gno.land/p/metamodel000/registry.gno
+++ b/projects/gnoland/gno.land/p/metamodel000/registry.gno
@@ -26,7 +26,7 @@ func NewRegistry(allowedPrefixes []string, renderOpts map[string]interface{}) *R
 	return &Registry{
 		tree:          avl.NewTree(),
 		allowPrefixes: allowedPrefixes,
-		renderOpts: renderOpts,
+		renderOpts:    renderOpts,
 	}
 }
 

--- a/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
@@ -1,10 +1,11 @@
 WIP
 ---
-- [ ] make sure HasRole and RenderCalendar are available at proper realms
-- [ ] add URL pointer for aiblabs etc..  for calendar events
+- [ ] finish refactoring component.RenderPage - we now have registery.Render() involved calling component... 
 
 BACKLOG
 -------
+- [ ] make sure HasRole and RenderCalendar are available at proper realms
+- [ ] add URL pointer for aiblabs etc..  for calendar events
 - [ ] self-audit patch permissions for each event's realm - is exposing LiveEvent() bad?
 - [ ] test content blocks with callbacks 
 - [ ] fix event.ToJson() to populate all fields states
@@ -12,6 +13,7 @@ BACKLOG
 - [ ] add version number to bottom of /events page
 - [ ] fix http://127.0.0.1:8888/r/buidlthefuture000/events/onsite001?format=ics
 - [ ] add banner view of component
+- [ ] review style of events in calendar
  
 DONE
 -----

--- a/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
@@ -10,6 +10,8 @@ BACKLOG
 - [ ] fix event.ToJson() to populate all fields states
 - [ ] fix/test the `/events` api
 - [ ] add version number to bottom of /events page
+- [ ] fix http://127.0.0.1:8888/r/buidlthefuture000/events/onsite001?format=ics
+- [ ] add banner view of component
  
 DONE
 -----

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/event.gno
@@ -9,8 +9,10 @@ import (
 
 func init() {
 	renderOpts := map[string]interface{}{
-		"Svg":          struct{}{},
-		"CalendarHost": "webcal://127.0.0.1:8080",
+		"SvgFooter":       struct{}{},                // enables SVG footer in the event flyer
+		"CalendarHost":    "webcal://127.0.0.1:8080", // external webcal server
+		"CalendarFile":    "http://127.0.0.1:8080",   // external calendar file server
+		"CalendarDataUrl": struct{}{},                // allows use of calendar without external server
 	}
 	app.RegisterEvent(gnolandlaunch, renderOpts)
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/public.gno
@@ -1,12 +1,16 @@
 package gnolandlaunch
 
+import (
+    "gno.land/p/eve000/event/component"
+)
+
 // join waitlist for event
 func JoinWaitlist() {
 	app.JoinWaitlist()
 }
 
 func RenderCalendar(path string) string {
-	return app.LiveEvent().Flyer().RenderCalendar(path)
+	return app.LiveEvent().Render(path, component.IcsCalendarFile)
 }
 
 func Render(path string) (out string) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/public.gno
@@ -6,7 +6,7 @@ func JoinWaitlist() {
 }
 
 func RenderCalendar(path string) string {
-	return app.LiveEvent().RenderCalendar(path)
+	return app.LiveEvent().Flyer().RenderCalendar(path)
 }
 
 func Render(path string) (out string) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
@@ -18,7 +18,7 @@ var (
 )
 
 func (*App) Render(path string) (out string) {
-	return registry.Render(path, banner)
+	return registry.Render(path, banner) // REVIEW: injecting content here
 }
 
 func (*App) SetContent(key, markdown string) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/event.gno
@@ -10,7 +10,7 @@ import (
 func init() {
 	renderOpts := map[string]interface{}{
 		"Speaker":      struct{}{},
-		"Svg":          struct{}{}, // FIXME verify svg appears on this Flyer
+		"SvgFooter":    struct{}{},
 		"CalendarHost": "webcal://127.0.0.1:8080",
 	}
 	app.RegisterEvent(gnolandlaunch, renderOpts)

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/public.gno
@@ -1,4 +1,7 @@
 package gnoplan
+import (
+    "gno.land/p/eve000/event/component"
+)
 
 // JoinBeta allows users to join the beta program for the Gno.land launch event.
 func JoinBeta() {
@@ -6,9 +9,9 @@ func JoinBeta() {
 }
 
 func RenderCalendar(path string) string {
-	return app.LiveEvent().Flyer().RenderCalendar(path)
+	return app.LiveEvent().Render(path, component.IcsCalendarFile)
 }
 
 func Render(path string) (out string) {
-	return app.Render(path) + "\n\n" + registry.GetPatchLevel() + "\n\n"
+	return app.Render(path) + "\n\n" + registry.GetPatchLevel() + "\n\n" // REVIEW: should this look like RenderCalendar?
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/public.gno
@@ -6,7 +6,7 @@ func JoinBeta() {
 }
 
 func RenderCalendar(path string) string {
-	return app.LiveEvent().RenderCalendar(path)
+	return app.LiveEvent().Flyer().RenderCalendar(path)
 }
 
 func Render(path string) (out string) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
@@ -9,7 +9,8 @@ import (
 
 func init() {
 	renderOpts := map[string]interface{}{
-		"Location": struct{}{},
+		"SvgFooter": struct{}{},
+		"Location":  struct{}{},
 	}
 	app.RegisterEvent(gnolandlaunch, renderOpts)
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/public.gno
@@ -1,7 +1,7 @@
 package onsite
 
 func RenderCalendar(path string) string {
-	return app.LiveEvent().RenderCalendar(path)
+	return app.LiveEvent().Flyer().RenderCalendar(path)
 }
 
 func Render(path string) (out string) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/public.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/public.gno
@@ -1,7 +1,11 @@
 package onsite
 
+import (
+    "gno.land/p/eve000/event/component"
+)
+
 func RenderCalendar(path string) string {
-	return app.LiveEvent().Flyer().RenderCalendar(path)
+	return app.LiveEvent().Render(path, component.IcsCalendarFile)
 }
 
 func Render(path string) (out string) {

--- a/projects/gnoland/gno.land/r/metamodel000/eve.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/eve.gno
@@ -19,15 +19,15 @@ The relationships between these files are as follows:
 `
 
 func init() {
-	eveModel := eve()
-	eveModel.Binding = func(_ string) string {
-		return folderLayout + eveModel.ToMarkdown()
+	folderModel := eventFolderLayout()
+	folderModel.Binding = func(_ string) string {
+		return folderLayout + folderModel.ToMarkdown()
 	}
-	register("EventFolderLayout", eveModel)
+	register("EventFolderLayout", folderModel)
 }
 
 // eve model shows the layout of the event folder
-func eve() *mm.Model {
+func eventFolderLayout() *mm.Model {
 	places := map[string]mm.Place{
 		"acl.gno":    {Offset: 0, X: 58, Y: 50},
 		"app.gno":    {Offset: 1, X: 275, Y: 100},
@@ -56,3 +56,4 @@ func eve() *mm.Model {
 		Arrows:      arrows,
 	}
 }
+

--- a/projects/gnoland/gno.land/r/metamodel000/index.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/index.gno
@@ -5,21 +5,21 @@ import (
 )
 
 var (
-    renderOpts = map[string]interface{}{
-        "Title":       "Metamodel000",
-        "Description": "A metamodel for Gno.land, providing various models and examples.",
-        "Author":      "Gno.land Team",
-        "Version":     "0.0.1",
-        "Date":        "2023-10-01",
-    }
+	renderOpts = map[string]interface{}{
+		"Title":       "Metamodel000",
+		"Description": "A metamodel for Gno.land, providing various models and examples.",
+		"Author":      "Gno.land Team",
+		"Version":     "0.0.1",
+		"Date":        "2023-10-01",
+	}
 
-    authorizedPaths = []string{
-        "gno.land/r/metamodel000",
-        "gno.land/p/metamodel000",
-        "",
-    }
+	authorizedPaths = []string{
+		"gno.land/r/metamodel000",
+		"gno.land/p/metamodel000",
+		"",
+	}
 
-    registry = mm.NewRegistry(authorizedPaths, renderOpts)
+	registry = mm.NewRegistry(authorizedPaths, renderOpts)
 )
 
 func Register(cur realm, key string, obj interface{}) {


### PR DESCRIPTION
- refines the RenderPage and RenderComponent usages
- Adds 3 ways to share ICS file - using RenderOpts to enable

Moved JsonLD and ICS templates to be 'Template' functions. The principle followed here is that ToJson ToSvg and ToMarkdown are included by any component, so anything beyond the default would ideally be a template function  outside of the component declaration. 

The Idea here is that if we got some part of the presentation wrong in the original approach the function shim that we'd use to restyle is clean

```
func IcsCalendarFile(path string, a *Flyer) string
func EventJsonLD(_ string, a *Flyer) string 
```

Instead of making these methods on Flyer - (which is a Component)

The RenderPage func *does* still rely on these methods being present.
```
func (a *Flyer) ToJsonLD() string {
	return EventJsonLD("?format=jsonld", a)
}

func (a *Flyer) ToIcs() string {
	return IcsCalendarFile("?format=ics", a)
}
```

However - also notice - that Events can now be styled w/ some syntactic sugar

```
func (evt *Event) Render(path string, tpl func(path string, flyer *component.Flyer) string) string 
```

The method above could accept ToJsonLD or ToIcs as a template - this is what we'd expect of other users who may just want to nest a single event in the page without using our registry.

The Registry Render func includes injectable body content ( which we use to display 'banner' actions in each of our event landing pages.

```
func (r *Registry) Render(path string, body ...component.Content) string
```




