### PR TITLE
Task/component refactor interfaces

### DIFF
--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -97,7 +97,7 @@ func (evt *Event) AddSpeaker(s *component.Speaker) {
 		evt.storage.Speakers = &avl.Tree{}
 	}
 	id := component.Pad3(strconv.Itoa(evt.storage.Speakers.Size()))
-	evt.storage.Speakers.Set(AvlKey("speaker", id), s)
+	evt.storage.Speakers.Set(component.Pad3(id), s)
 }
 
 func (evt *Event) AddLocation(loc *component.Location) {
@@ -108,7 +108,7 @@ func (evt *Event) AddLocation(loc *component.Location) {
 		evt.storage.Locations = &avl.Tree{}
 	}
 	id := component.Pad3(strconv.Itoa(evt.storage.Locations.Size()))
-	evt.storage.Locations.Set(AvlKey("location", id), loc)
+	evt.storage.Locations.Set(component.Pad3(id), loc)
 }
 
 func (evt *Event) AddSession(sess *component.Session) {
@@ -120,11 +120,11 @@ func (evt *Event) AddSession(sess *component.Session) {
 	}
 	// TODO: maybe Pad3 can accept interface so extras stringconv isn't needed here
 	id := component.Pad3(strconv.Itoa(evt.storage.Sessions.Size()))
-	evt.storage.Sessions.Set(AvlKey("session", id), sess)
+	evt.storage.Sessions.Set(component.Pad3(id), sess)
 }
 
 func (evt *Event) GetSpeaker(id string) *component.Speaker {
-	s, ok := evt.storage.Speakers.Get(AvlKey("speaker", id))
+	s, ok := evt.storage.Speakers.Get(component.Pad3(id))
 	if !ok {
 		panic("speaker not found: id=" + id)
 	}
@@ -132,7 +132,7 @@ func (evt *Event) GetSpeaker(id string) *component.Speaker {
 }
 
 func (evt *Event) GetLocation(id string) *component.Location {
-	l, ok := evt.storage.Locations.Get(AvlKey("location", id))
+	l, ok := evt.storage.Locations.Get(component.Pad3(id))
 	if !ok {
 		panic("location not found: id=" + id)
 	}
@@ -140,44 +140,39 @@ func (evt *Event) GetLocation(id string) *component.Location {
 }
 
 func (evt *Event) GetSession(id string) *component.Session {
-	s, ok := evt.storage.Sessions.Get(AvlKey("session", id))
+	s, ok := evt.storage.Sessions.Get(component.Pad3(id))
 	if !ok {
 		panic("session not found: id=" + id)
 	}
 	return s.(*component.Session)
 }
 
-// REVIEW: is this used?
-func (evt *Event) GetSessions() []*component.Session {
-	if evt.storage == nil || evt.storage.Sessions == nil {
-		return nil
-	}
-	var sessions []*component.Session
-	evt.storage.Sessions.IterateByOffset(0, evt.storage.Sessions.Size(), func(_ string, val any) bool {
-		s := val.(*component.Session)
-		sessions = append(sessions, s)
-		return false
-	})
-	return sessions
-}
 func (evt *Event) Flyer() *component.Flyer {
 	flyer := &component.Flyer{
 		Name:        evt.Name,
-		Location:    evt.Location,
+		Location:    nil,
 		StartDate:   evt.StartDate,
 		EndDate:     evt.EndDate,
 		Status:      evt.Status,
 		Description: evt.Description,
-		Sessions:    evt.Sessions,
-		Images:      evt.Images,
+		Sessions:    nil,
+		Images:      append([]string(nil), evt.Images...),
+	}
+	if evt.Location != nil {
+		loc := *evt.Location
+		flyer.Location = &loc
+	}
+	if evt.Sessions != nil {
+		flyer.Sessions = make([]*component.Session, len(evt.Sessions))
+		for i, s := range evt.Sessions {
+			if s != nil {
+				sessionCopy := *s
+				flyer.Sessions[i] = &sessionCopy
+			}
+		}
 	}
 	flyer.SetRenderOpts(evt.renderOpts)
 	return flyer
-}
-
-// build a key for the AVL tree like "event:123" "speaker:456" or "location:789"
-func AvlKey(label string, id string) string {
-	return component.Pad3(id)
 }
 
 // Event may not be a component (yet!) but it is where the render opts are stored.

--- a/projects/gnoland/gno.land/p/eve000/event/registry.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/registry.gno
@@ -67,7 +67,7 @@ func (r *Registry) SetPatchLevel(level int) {
 }
 
 func (r *Registry) GetEvent(id string) *Event {
-	e, ok := r.Events.Get(AvlKey("event", id))
+	e, ok := r.Events.Get(component.Pad3(id))
 	if !ok {
 		panic("event not found" + id)
 	}

--- a/projects/gnoland/gno.land/p/metamodel000/registry.gno
+++ b/projects/gnoland/gno.land/p/metamodel000/registry.gno
@@ -205,7 +205,7 @@ func (r *Registry) thumbnail(key string, obj interface{}) string {
 		return "![" + key + "](" + model.ThumbnailDataUrl() + ")\n" +
 			r.Preview(key, "") + "\n"
 	case ContentBlock:
-		return "[no thumbnail]\n"
+		return "[POST] - " + r.Preview(key, "") + "\n"
 	default:
 		return "[default]\n"
 	}

--- a/projects/gnoland/gno.land/r/metamodel000/eve.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/eve.gno
@@ -56,3 +56,95 @@ func eventFolderLayout() *mm.Model {
 		Arrows:      arrows,
 	}
 }
+
+var eventCompositionLayout = `
+This section describes the structure of an [Eve event](/p/eve000/event).
+
+For the purposes of this model, an event is thought of as a composition of the following component types:
+
+- **EventStatus**: Indicates the current status of the event (e.g., scheduled, cancelled).
+- **EventAttendanceMode**: Specifies how the event can be attended (e.g., online, offline, mixed).
+- **Speakers**: Lists the speakers participating in the event.
+- **Locations**: Lists the locations where the event takes place.
+- **RenderOpts**: Contains options for rendering the event.
+- **Event**: Represents the event as a whole.
+- **Sessions**: Contains the sessions that make up the event.
+- **Flyer**: A visual component that can be rendered for the event.
+- **EventDetails**: Provides details such as start date, end date, and description.
+- **ContentBlock**: Allows for additional content to be injected into the flyer.
+
+Each component is represented as a "place" in the model. "Transitions" define the relationships between these components, such as linking speakers and locations to sessions, or connecting event status and attendance mode to the event itself.
+
+Arrows in the model illustrate how information flows between components, showing their interactions and how they together form a complete event model.
+
+- **Inhibitor arcs** (arrows with **Inhibit: true**) are used to indicate type separation or constraints between components.
+
+
+Notice that this model has a rule, an Event requires > 1 session before it can be created.
+
+Additionally the same relation is seen between Event and Flyer, event must exist before a Flyer can be created.
+`
+
+func init() {
+    eventModel := eventComposition()
+    eventModel.Binding = func(_ string) string {
+        return eventCompositionLayout + eventModel.ToMarkdown()
+    }
+    register("EventComposition", eventModel)
+}
+
+func eventComposition() *mm.Model {
+	places := map[string]mm.Place{
+		"EventStatus":          {Offset: 0, Initial: mm.T(1), X: 435, Y: 147},
+		"EventAttendanceMode":  {Offset: 1, Initial: mm.T(1), X: 432, Y: 200},
+		"Speakers":             {Offset: 2, X: 200, Y: 320},
+		"Locations":            {Offset: 3, X: 200, Y: 440},
+		"RenderOpts":           {Offset: 4, Initial: mm.T(1), X: 782, Y: 216},
+		"Event":                {Offset: 5, X: 788, Y: 137},
+		"Sessions":             {Offset: 6, X: 440, Y: 320},
+		"Flyer":                {Offset: 7, X: 972, Y: 178},
+		"EventDetails":         {Offset: 8, Initial: mm.T(1), X: 436, Y: 93},
+		"ContentBlock":         {Offset: 9, Initial: mm.T(1), X: 974, Y: 260},
+	}
+
+	transitions := map[string]mm.Transition{
+		"(Speaker)":                  {X: 320, Y: 320},
+		"(Location)":                 {X: 320, Y: 440},
+		"(Speaker,Location)":         {X: 320, Y: 380},
+		"(Status,Attendance,Sessions)": {X: 605, Y: 138},
+		"Location":                   {X: 80, Y: 440},
+		"Session":                    {X: 320, Y: 240},
+		"Speaker":                    {X: 80, Y: 320},
+		"Flyer()":                    {X: 890, Y: 177},
+		"Render()":                   {X: 1071, Y: 207},
+	}
+
+	arrows := []mm.Arrow{
+		{Source: "EventStatus", Target: "(Status,Attendance,Sessions)"},
+		{Source: "EventAttendanceMode", Target: "(Status,Attendance,Sessions)"},
+		{Source: "Speakers", Target: "(Speaker)"},
+		{Source: "Locations", Target: "(Location)"},
+		{Source: "Speakers", Target: "(Speaker,Location)"},
+		{Source: "Locations", Target: "(Speaker,Location)"},
+		{Source: "(Speaker)", Target: "Sessions"},
+		{Source: "(Location)", Target: "Sessions"},
+		{Source: "(Speaker,Location)", Target: "Sessions"},
+		{Source: "Speaker", Target: "Speakers"},
+		{Source: "Location", Target: "Locations"},
+		{Source: "(Status,Attendance,Sessions)", Target: "Event"},
+		{Source: "Flyer()", Target: "Event", Inhibit: true},
+		{Source: "RenderOpts", Target: "Flyer()"},
+		{Source: "(Status,Attendance,Sessions)", Target: "Sessions", Inhibit: true},
+		{Source: "Session", Target: "Sessions"},
+		{Source: "Flyer()", Target: "Flyer"},
+		{Source: "EventDetails", Target: "(Status,Attendance,Sessions)"},
+		{Source: "Flyer", Target: "Render()"},
+		{Source: "ContentBlock", Target: "Render()"},
+	}
+
+	return &mm.Model{
+		Places:      places,
+		Transitions: transitions,
+		Arrows:      arrows,
+	}
+}

--- a/projects/gnoland/gno.land/r/metamodel000/eve.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/eve.gno
@@ -86,37 +86,37 @@ Additionally the same relation is seen between Event and Flyer, event must exist
 `
 
 func init() {
-    eventModel := eventComposition()
-    eventModel.Binding = func(_ string) string {
-        return eventCompositionLayout + eventModel.ToMarkdown()
-    }
-    register("EventComposition", eventModel)
+	eventModel := eventComposition()
+	eventModel.Binding = func(_ string) string {
+		return eventCompositionLayout + eventModel.ToMarkdown()
+	}
+	register("EventComposition", eventModel)
 }
 
 func eventComposition() *mm.Model {
 	places := map[string]mm.Place{
-		"EventStatus":          {Offset: 0, Initial: mm.T(1), X: 435, Y: 147},
-		"EventAttendanceMode":  {Offset: 1, Initial: mm.T(1), X: 432, Y: 200},
-		"Speakers":             {Offset: 2, X: 200, Y: 320},
-		"Locations":            {Offset: 3, X: 200, Y: 440},
-		"RenderOpts":           {Offset: 4, Initial: mm.T(1), X: 782, Y: 216},
-		"Event":                {Offset: 5, X: 788, Y: 137},
-		"Sessions":             {Offset: 6, X: 440, Y: 320},
-		"Flyer":                {Offset: 7, X: 972, Y: 178},
-		"EventDetails":         {Offset: 8, Initial: mm.T(1), X: 436, Y: 93},
-		"ContentBlock":         {Offset: 9, Initial: mm.T(1), X: 974, Y: 260},
+		"EventStatus":         {Offset: 0, Initial: mm.T(1), X: 435, Y: 147},
+		"EventAttendanceMode": {Offset: 1, Initial: mm.T(1), X: 432, Y: 200},
+		"Speakers":            {Offset: 2, X: 200, Y: 320},
+		"Locations":           {Offset: 3, X: 200, Y: 440},
+		"RenderOpts":          {Offset: 4, Initial: mm.T(1), X: 782, Y: 216},
+		"Event":               {Offset: 5, X: 788, Y: 137},
+		"Sessions":            {Offset: 6, X: 440, Y: 320},
+		"Flyer":               {Offset: 7, X: 972, Y: 178},
+		"EventDetails":        {Offset: 8, Initial: mm.T(1), X: 436, Y: 93},
+		"ContentBlock":        {Offset: 9, Initial: mm.T(1), X: 974, Y: 260},
 	}
 
 	transitions := map[string]mm.Transition{
-		"(Speaker)":                  {X: 320, Y: 320},
-		"(Location)":                 {X: 320, Y: 440},
-		"(Speaker,Location)":         {X: 320, Y: 380},
+		"(Speaker)":                    {X: 320, Y: 320},
+		"(Location)":                   {X: 320, Y: 440},
+		"(Speaker,Location)":           {X: 320, Y: 380},
 		"(Status,Attendance,Sessions)": {X: 605, Y: 138},
-		"Location":                   {X: 80, Y: 440},
-		"Session":                    {X: 320, Y: 240},
-		"Speaker":                    {X: 80, Y: 320},
-		"Flyer()":                    {X: 890, Y: 177},
-		"Render()":                   {X: 1071, Y: 207},
+		"Location":                     {X: 80, Y: 440},
+		"Session":                      {X: 320, Y: 240},
+		"Speaker":                      {X: 80, Y: 320},
+		"Flyer()":                      {X: 890, Y: 177},
+		"Render()":                     {X: 1071, Y: 207},
 	}
 
 	arrows := []mm.Arrow{

--- a/projects/gnoland/gno.land/r/metamodel000/qwerty.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/qwerty.gno
@@ -1,0 +1,80 @@
+package metamodel
+
+import (
+	mm "gno.land/p/metamodel000"
+)
+
+var qwertyNotes string = `
+This is a QWERTY keyboard layout model.
+
+Though not overly useful in itself, it serves as a demonstration that inputs without any place constraints are identical to pure transition models.
+
+Thus, we can control a re-usable model vocabulary that can be built upon by appending arrows and places to the model.
+`
+var externalLink = `[![pflow](https://pflow.dev/img/zb2rhoVtN4MTsEuAEL6eMDog85mvLx91jG5LTnnDZ6fxxqVRb.svg)](https://pflow.dev/p/zb2rhoVtN4MTsEuAEL6eMDog85mvLx91jG5LTnnDZ6fxxqVRb/)`
+
+
+func init() {
+	keyboard := qwertyModel()
+	keyboard.Binding = func(_ string) string {
+	    return qwertyNotes + keyboard.ToMarkdown()
+	}
+	// FIXME: adding this model crashes gnoweb w/ a stackoverflow
+    // gnodev-labs-1  | runtime: goroutine stack exceeds 1GB limit
+	// gnodev-labs-1  | runtime: sp=0x40395de3a0 stack=[0x40395de000, 0x40595de000]
+	// gnodev-labs-1  | fatal error: stack overflow
+
+	// affecting only the index view - it works for individual views
+	// http://127.0.0.1:8888/r/metamodel000?i=2
+
+    var staticContent = true // workaround for gnoweb stack overflow issue
+
+    if staticContent {
+        // Register the model with an external link
+        register("Keyboard", func(_ string) string {
+            return qwertyNotes + externalLink
+        })
+    } else {
+        // Register the model directly
+        register("Keyboard", keyboard)
+    }
+}
+
+func qwertyModel() *mm.Model {
+	transitions := map[string]mm.Transition{
+		"A":        {X: 125, Y: 160},
+		"B":        {X: 350, Y: 220},
+		"C":        {X: 250, Y: 220},
+		"D":        {X: 225, Y: 160},
+		"E":        {X: 200, Y: 100},
+		"Enter":    {X: 580, Y: 160},
+		"F":        {X: 275, Y: 160},
+		"G":        {X: 325, Y: 160},
+		"H":        {X: 375, Y: 160},
+		"I":        {X: 450, Y: 100},
+		"J":        {X: 425, Y: 160},
+		"K":        {X: 475, Y: 160},
+		"L":        {X: 525, Y: 160},
+		"M":        {X: 450, Y: 220},
+		"N":        {X: 400, Y: 220},
+		"O":        {X: 500, Y: 100},
+		"P":        {X: 550, Y: 100},
+		"Q":        {X: 100, Y: 100},
+		"R":        {X: 250, Y: 100},
+		"S":        {X: 175, Y: 160},
+		"Spacebar": {X: 300, Y: 280},
+		"T":        {X: 300, Y: 100},
+		"U":        {X: 400, Y: 100},
+		"V":        {X: 300, Y: 220},
+		"W":        {X: 150, Y: 100},
+		"X":        {X: 200, Y: 220},
+		"Y":        {X: 350, Y: 100},
+		"Z":        {X: 150, Y: 220},
+	}
+
+	return &mm.Model{
+		Places:      map[string]mm.Place{}, // No places defined in the model
+		Transitions: transitions,
+		Arrows:      []mm.Arrow{}, // No arcs defined in the model
+	}
+}


### PR DESCRIPTION
- Small refactor to  remove 'AvlKey' func in favor of Pad3.
- Adds a metamodel of EveComponents as compsition
- Adds a post under /r/metamodel000 for 'Keyboard' (a simple model of qwerty)

NOTE: adjusting the Keyboard model to use register (like all other models) causes the error below.


```
	// FIXME: adding this model crashes gnoweb w/ a stackoverflow
	// gnodev-labs-1  | runtime: goroutine stack exceeds 1GB limit
	// gnodev-labs-1  | runtime: sp=0x40395de3a0 stack=[0x40395de000, 0x40595de000]
	// gnodev-labs-1  | fatal error: stack overflow

	// affecting only the index view - it works for individual views
	// http://127.0.0.1:8888/r/metamodel000?i=2

	var staticContent = true // workaround for gnoweb stack overflow issue

	if staticContent {
		// Register the model with an external link
		register("Keyboard", func(_ string) string {
			return qwertyNotes + externalLink
		})
	} else {
		// Register the model directly
		register("Keyboard", keyboard)
	}
```