### PR TITLE
fix: update labsnet to match test7.2

### DIFF
--- a/projects/gnoland/Dockerfile
+++ b/projects/gnoland/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/gnolang/gno/gnodev:0.0.1-560a63109-master
+# Test 7.2 Hash
+FROM ghcr.io/gnolang/gno/gnodev:sha-9b384d4
 
 RUN apk add --no-cache ca-certificates bash
 

--- a/projects/gnoland/Dockerfile_testrunner
+++ b/projects/gnoland/Dockerfile_testrunner
@@ -1,4 +1,4 @@
-FROM ghcr.io/gnolang/gno:0.0.1-560a63109-master
+FROM ghcr.io/gnolang/gno:0.0.1-de4b5b56c-master
 
 RUN apk add --no-cache ca-certificates bash
 

--- a/projects/gnoland/README.md
+++ b/projects/gnoland/README.md
@@ -2,7 +2,9 @@
 
 This is a repository meant to hold all gno.land smart contract related `p/` and `r/` files.
 
-This has a local development environment so that you can run `make dev` and it will spin up hot-reload for `examples` as well as all the files in this directory. 
+This has a local development environment so that you can run `make dev` and it will spin up hot-reload for `examples` as well as all the files in this directory.
+
+`labsneet` current matches `test7.2` using `sha-9b384d4` as the tagged image
 
 ## Quick Start
 


### PR DESCRIPTION
This patch puts us on parity with test7.2 on gnoland