### PR TITLE
Fix/event render noregistry

### DIFF
--- a/projects/gnoland/gno.land/p/eve000/event/component/calendar.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/calendar.gno
@@ -2,7 +2,6 @@ package component
 
 import (
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -61,7 +60,7 @@ func IcsCalendarFile(path string, a *Flyer) string {
 		w("END:VEVENT\n")
 
 		for i, s := range a.Sessions {
-			id := Pad3(strconv.Itoa(i))
+			id := Pad3(i)
 			if !include(id) {
 				continue
 			}
@@ -91,7 +90,7 @@ func IcsCalendarFile(path string, a *Flyer) string {
 	default:
 		w(f("# %s\n\n%s", a.Name, a.Description))
 		for i, s := range a.Sessions {
-			id := Pad3(strconv.Itoa(i))
+			id := Pad3(i)
 			if !include(id) {
 				continue
 			}

--- a/projects/gnoland/gno.land/p/eve000/event/component/component.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/component.gno
@@ -296,7 +296,18 @@ func slugify(s string) string {
 	return strings.Trim(re.ReplaceAllString(strings.ToLower(s), "-"), "-")
 }
 
-func Pad3(s string) string {
+func Pad3(val interface{}) string {
+	var s string
+	switch v := val.(type) {
+	case string:
+		s = v
+	case int:
+		s = strconv.Itoa(v)
+	case int64:
+		s = strconv.FormatInt(v, 10)
+	default:
+		panic("Pad3: unsupported type")
+	}
 	for len(s) < 3 {
 		s = "0" + s
 	}

--- a/projects/gnoland/gno.land/p/eve000/event/component/flyer.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/component/flyer.gno
@@ -110,7 +110,7 @@ func (a *Flyer) ToMarkdown(body ...Content) string {
 		markdown += "## Locations\n\n" + locationsMarkdown
 	}
 	if _, ok := a.RenderOpts()["SvgFooter"]; ok {
-		markdown += "[![Flyer SVG](" + a.ToSvgDataUrl() + ")](" + a.ToAnchor() + ")\n\n"
+		markdown += "\n\n[![Flyer SVG](" + a.ToSvgDataUrl() + ")](" + a.ToAnchor() + ")\n\n"
 	}
 
 	return markdown

--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"gno.land/p/demo/avl"
-	"gno.land/p/eve000/event/component"
+	eve "gno.land/p/eve000/event/component"
 )
 
 // FIXME either change interface or satisfy it
@@ -53,13 +53,13 @@ type Storage struct {
 // the event object is protected for edits only by patching from specific 'sub-realms'
 type Event struct {
 	Name           string
-	Location       *component.Location
+	Location       *eve.Location
 	StartDate      time.Time
 	EndDate        time.Time
 	Description    string
-	Sessions       []*component.Session
-	Status         component.EventStatus
-	AttendanceMode component.EventAttendanceMode
+	Sessions       []*eve.Session
+	Status         eve.EventStatus
+	AttendanceMode eve.EventAttendanceMode
 	Images         []string
 	renderOpts     map[string]interface{}
 	storage        *Storage
@@ -69,7 +69,7 @@ func (evt *Event) SetEventName(name string) {
 	evt.Name = name
 }
 
-func (evt *Event) SetEventLocation(loc *component.Location) {
+func (evt *Event) SetEventLocation(loc *eve.Location) {
 	evt.Location = loc
 }
 
@@ -85,70 +85,69 @@ func (evt *Event) SetEventDescription(description string) {
 	evt.Description = description
 }
 
-func (evt *Event) SetSessions(sessions []*component.Session) {
+func (evt *Event) SetSessions(sessions []*eve.Session) {
 	evt.Sessions = sessions
 }
 
-func (evt *Event) AddSpeaker(s *component.Speaker) {
+func (evt *Event) AddSpeaker(s *eve.Speaker) {
 	if evt.storage == nil {
 		evt.storage = &Storage{}
 	}
 	if evt.storage.Speakers == nil {
 		evt.storage.Speakers = &avl.Tree{}
 	}
-	id := component.Pad3(strconv.Itoa(evt.storage.Speakers.Size()))
-	evt.storage.Speakers.Set(component.Pad3(id), s)
+	id := eve.Pad3(evt.storage.Speakers.Size())
+	evt.storage.Speakers.Set(eve.Pad3(id), s)
 }
 
-func (evt *Event) AddLocation(loc *component.Location) {
+func (evt *Event) AddLocation(loc *eve.Location) {
 	if evt.storage == nil {
 		evt.storage = &Storage{}
 	}
 	if evt.storage.Locations == nil {
 		evt.storage.Locations = &avl.Tree{}
 	}
-	id := component.Pad3(strconv.Itoa(evt.storage.Locations.Size()))
-	evt.storage.Locations.Set(component.Pad3(id), loc)
+	id := eve.Pad3(evt.storage.Locations.Size())
+	evt.storage.Locations.Set(eve.Pad3(id), loc)
 }
 
-func (evt *Event) AddSession(sess *component.Session) {
+func (evt *Event) AddSession(sess *eve.Session) {
 	if evt.storage == nil {
 		evt.storage = &Storage{}
 	}
 	if evt.storage.Sessions == nil {
 		evt.storage.Sessions = &avl.Tree{}
 	}
-	// TODO: maybe Pad3 can accept interface so extras stringconv isn't needed here
-	id := component.Pad3(strconv.Itoa(evt.storage.Sessions.Size()))
-	evt.storage.Sessions.Set(component.Pad3(id), sess)
+	id := eve.Pad3(strconv.Itoa(evt.storage.Sessions.Size()))
+	evt.storage.Sessions.Set(eve.Pad3(id), sess)
 }
 
-func (evt *Event) GetSpeaker(id string) *component.Speaker {
-	s, ok := evt.storage.Speakers.Get(component.Pad3(id))
+func (evt *Event) GetSpeaker(id string) *eve.Speaker {
+	s, ok := evt.storage.Speakers.Get(eve.Pad3(id))
 	if !ok {
 		panic("speaker not found: id=" + id)
 	}
-	return s.(*component.Speaker)
+	return s.(*eve.Speaker)
 }
 
-func (evt *Event) GetLocation(id string) *component.Location {
-	l, ok := evt.storage.Locations.Get(component.Pad3(id))
+func (evt *Event) GetLocation(id string) *eve.Location {
+	l, ok := evt.storage.Locations.Get(eve.Pad3(id))
 	if !ok {
 		panic("location not found: id=" + id)
 	}
-	return l.(*component.Location)
+	return l.(*eve.Location)
 }
 
-func (evt *Event) GetSession(id string) *component.Session {
-	s, ok := evt.storage.Sessions.Get(component.Pad3(id))
+func (evt *Event) GetSession(id string) *eve.Session {
+	s, ok := evt.storage.Sessions.Get(eve.Pad3(id))
 	if !ok {
 		panic("session not found: id=" + id)
 	}
-	return s.(*component.Session)
+	return s.(*eve.Session)
 }
 
-func (evt *Event) Flyer() *component.Flyer {
-	flyer := &component.Flyer{
+func (evt *Event) Flyer() *eve.Flyer {
+	flyer := &eve.Flyer{
 		Name:        evt.Name,
 		Location:    nil,
 		StartDate:   evt.StartDate,
@@ -163,7 +162,7 @@ func (evt *Event) Flyer() *component.Flyer {
 		flyer.Location = &loc
 	}
 	if evt.Sessions != nil {
-		flyer.Sessions = make([]*component.Session, len(evt.Sessions))
+		flyer.Sessions = make([]*eve.Session, len(evt.Sessions))
 		for i, s := range evt.Sessions {
 			if s != nil {
 				sessionCopy := *s
@@ -175,20 +174,36 @@ func (evt *Event) Flyer() *component.Flyer {
 	return flyer
 }
 
-// Event may not be a component (yet!) but it is where the render opts are stored.
 func (evt *Event) RenderOpts() map[string]interface{} {
 	return evt.renderOpts
 }
 
+func (evt *Event) initStorage() {
+	for _, s := range evt.Sessions {
+		evt.AddSession(s)
+		evt.AddSpeaker(s.Speaker)
+		evt.AddLocation(s.Location)
+	}
+
+}
+
 func (evt *Event) SetRenderOpts(opts map[string]interface{}) {
 	evt.renderOpts = opts
+	if evt.storage == nil {
+		evt.initStorage()
+	}
+	for _, s := range evt.Sessions {
+		s.SetRenderOpts(opts)
+		s.Speaker.SetRenderOpts(opts)
+		s.Location.SetRenderOpts(opts)
+	}
 }
 
 func (evt *Event) ToAnchor() string {
-	return component.StringToAnchor(evt.Name)
+	return eve.StringToAnchor(evt.Name)
 }
 
 // Render provides a syntactic sugar for rendering a Flyer using a template function.
-func (evt *Event) Render(path string, tpl func(path string, flyer *component.Flyer) string) string {
+func (evt *Event) Render(path string, tpl func(path string, flyer *eve.Flyer) string) string {
 	return tpl(path, evt.Flyer())
 }

--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -9,9 +9,6 @@ import (
 	eve "gno.land/p/eve000/event/component"
 )
 
-// FIXME either change interface or satisfy it
-//var _ Api = (*Event)(nil)
-
 type Api interface {
 	AddOrganizer(addr std.Address)
 	AddProposer(addr, sender std.Address)
@@ -24,6 +21,8 @@ type Api interface {
 	JoinAsAttendee()
 	JoinWaitlist()
 	ListRoles() []string
+	// REVIEW: should setLive Event be part of the API? - we may not use due to versioning issues
+	PublishEvent(evt *Event, opts map[string]interface{}) string
 	RegisterEvent(evt *Event, opts map[string]interface{}) string
 	RemoveOrganizer(addr std.Address)
 	RemoveProposer(addr, sender std.Address)

--- a/projects/gnoland/gno.land/p/eve000/event/registry.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/registry.gno
@@ -88,16 +88,6 @@ func (r *Registry) RegisterEvent(e *Event, opts map[string]interface{}) string {
 	}
 	e.SetRenderOpts(opts)
 
-	// REVIEW: is there a better way to inject options?
-	for _, s := range e.Sessions {
-		s.SetRenderOpts(opts)
-		e.AddSession(s)
-		s.Speaker.SetRenderOpts(opts)
-		e.AddSpeaker(s.Speaker) // REVIEW: why call addSpeaker if record was included as input?
-		s.Location.SetRenderOpts(opts)
-		e.AddLocation(s.Location)
-	}
-
 	id := component.Pad3(strconv.Itoa(r.Events.Size())) // 001, 002, etc.
 	r.Events.Set(id, e)
 	return id

--- a/projects/gnoland/gno.land/p/eve000/event/registry.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/registry.gno
@@ -8,7 +8,7 @@ import (
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
-	"gno.land/p/eve000/event/component"
+	eve "gno.land/p/eve000/event/component"
 )
 
 type Registry struct {
@@ -19,7 +19,7 @@ type Registry struct {
 	patchRealm  string // realm that is allowed to update the patch level, used for debugging and content management
 }
 
-func (r *Registry) Render(path string, body ...component.Content) string {
+func (r *Registry) Render(path string, body ...eve.Content) string {
 	fullURL := std.CurrentRealm().PkgPath() + path // REVIEW: is this really needed?
 	u, err := url.Parse(fullURL)
 	if err != nil {
@@ -32,14 +32,14 @@ func (r *Registry) Render(path string, body ...component.Content) string {
 	}
 	evt := r.GetEvent(event_id)
 	switch {
-	case component.HasQueryParam(q, "session"):
-		return component.RenderComponent(path, evt.GetSession(q.Get("session")))
-	case component.HasQueryParam(q, "location"):
-		return component.RenderComponent(path, evt.GetLocation(q.Get("location")))
-	case component.HasQueryParam(q, "speaker"):
-		return component.RenderComponent(path, evt.GetSpeaker(q.Get("speaker")))
+	case eve.HasQueryParam(q, "session"):
+		return eve.RenderComponent(path, evt.GetSession(q.Get("session")))
+	case eve.HasQueryParam(q, "location"):
+		return eve.RenderComponent(path, evt.GetLocation(q.Get("location")))
+	case eve.HasQueryParam(q, "speaker"):
+		return eve.RenderComponent(path, evt.GetSpeaker(q.Get("speaker")))
 	default:
-		return component.RenderPage(path, evt.Flyer(), body...)
+		return eve.RenderPage(path, evt.Flyer(), body...)
 	}
 }
 
@@ -67,7 +67,7 @@ func (r *Registry) SetPatchLevel(level int) {
 }
 
 func (r *Registry) GetEvent(id string) *Event {
-	e, ok := r.Events.Get(component.Pad3(id))
+	e, ok := r.Events.Get(eve.Pad3(id))
 	if !ok {
 		panic("event not found" + id)
 	}
@@ -88,7 +88,7 @@ func (r *Registry) RegisterEvent(e *Event, opts map[string]interface{}) string {
 	}
 	e.SetRenderOpts(opts)
 
-	id := component.Pad3(strconv.Itoa(r.Events.Size())) // 001, 002, etc.
+	id := eve.Pad3(r.Events.Size())
 	r.Events.Set(id, e)
 	return id
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
@@ -1,13 +1,23 @@
 WIP
 ---
+High level TODOs for eve
+
+- [ ] Focus on separation between Event -> Flyer objects for security and developer api
+- [ ] Refine ACL to make it more flexible between events
+- [ ] Test /events api with all registered events
+- [ ] Audit for security issues with event permissions re: realm-based perms
+- [ ] add rendering tests for each type of supported event config location/speaker/cancelled events
+
+Consider a possible work-around for inability to share directly
+- we could integrate w/ google calendar - manually importing and ICS then sharing that link
+
+BACKLOG
+-------
+
 - [ ] test ICS integration with gnocal server
 - [ ] make sure HasRole and RenderCalendar are available at proper realms
 - [ ] add URL pointers for aiblabs domain (for testing on aiblabs.com)
 - [ ] fix event.ToJsonLD() to populate all fields states
-
-BACKLOG
--------
- 
 - [ ] update gnocal server to have a landing page in html, SVG + w/ jsonLD nested for structured data
 - [ ] fix/test the `/events` api
 - [ ] consider refactoring acl.gno for each event's specific needs
@@ -17,7 +27,3 @@ BACKLOG
  
 DONE
 -----
-- [x] fix http://127.0.0.1:8888/r/buidlthefuture000/events/onsite001?format=ics
-- [x] finish refactoring component.RenderPage - we now have registery.Render() involved calling component...
-- [x] add version number to bottom of /events page
-

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/app.gno
@@ -4,7 +4,7 @@ import (
 	"std"
 
 	"gno.land/p/eve000/event"
-	"gno.land/p/eve000/event/component"
+	eve "gno.land/p/eve000/event/component"
 )
 
 type App struct{}
@@ -23,7 +23,7 @@ func (*App) Render(path string) (out string) {
 }
 
 func (*App) RenderCalendar(path string) string {
-	return app.LiveEvent().Render(path, component.IcsCalendarFile)
+	return app.LiveEvent().Render(path, eve.IcsCalendarFile)
 }
 
 func (*App) SetContent(key, markdown string) {
@@ -47,11 +47,15 @@ func (*App) LiveEvent() *event.Event {
 	return registry.GetEvent(registry.LiveEventId)
 }
 
-func (*App) RegisterEvent(evt *event.Event, opts map[string]interface{}) string {
-	registry.SetRenderOpts(opts)
-	id := registry.RegisterEvent(evt, opts)
+func (*App) PublishEvent(evt *event.Event, opts map[string]interface{}) string {
+	id := app.RegisterEvent(evt, opts)
 	registry.LiveEventId = id
 	return id
+}
+
+func (*App) RegisterEvent(evt *event.Event, opts map[string]interface{}) string {
+	registry.SetRenderOpts(opts)
+	return registry.RegisterEvent(evt, opts)
 }
 
 func (*App) AdminSetRole(role string, addr std.Address) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/app.gno
@@ -4,7 +4,7 @@ import (
 	"std"
 
 	"gno.land/p/eve000/event"
-	"gno.land/p/eve000/event/component"
+	eve "gno.land/p/eve000/event/component"
 )
 
 type App struct{}
@@ -23,7 +23,7 @@ func (*App) Render(path string) (out string) {
 }
 
 func (*App) RenderCalendar(path string) string {
-	return app.LiveEvent().Render(path, component.IcsCalendarFile)
+	return app.LiveEvent().Render(path, eve.IcsCalendarFile)
 }
 
 func (*App) SetContent(key, markdown string) {
@@ -47,11 +47,15 @@ func (*App) LiveEvent() *event.Event {
 	return registry.GetEvent(registry.LiveEventId)
 }
 
-func (*App) RegisterEvent(evt *event.Event, opts map[string]interface{}) string {
-	registry.SetRenderOpts(opts)
-	id := registry.RegisterEvent(evt, opts)
+func (*App) PublishEvent(evt *event.Event, opts map[string]interface{}) string {
+	id := app.RegisterEvent(evt, opts)
 	registry.LiveEventId = id
 	return id
+}
+
+func (*App) RegisterEvent(evt *event.Event, opts map[string]interface{}) string {
+	registry.SetRenderOpts(opts)
+	return registry.RegisterEvent(evt, opts)
 }
 
 func (*App) AdminSetRole(role string, addr std.Address) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/event.gno
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"gno.land/p/eve000/event"
-	"gno.land/p/eve000/event/component"
+	eve "gno.land/p/eve000/event/component"
 )
 
 func init() {
@@ -17,13 +17,13 @@ func init() {
 }
 
 // banner content block is shown in the top section of the event page
-var banner = component.Content{
+var banner = eve.Content{
 	Published: true,
 	Markdown: "\n\n#### Status: Seeking Stakeholders for Planning \n\n" +
-		component.TxlinkButton("Join Beta", "JoinBeta"),
+		eve.TxlinkButton("Join Beta", "JoinBeta"),
 }
 
-var locations = map[string]*component.Location{
+var locations = map[string]*eve.Location{
 	"gnowhere": {
 		Name:        "Gnowhere",
 		Description: "",
@@ -34,7 +34,7 @@ var locations = map[string]*component.Location{
 	},
 }
 
-var speakerBios = map[string]*component.Speaker{
+var speakerBios = map[string]*eve.Speaker{
 	"mason": {
 		Name:        "Mason",
 		Biography:   "Nathan is a member of AIBLabs working on Eve event platform.",
@@ -56,7 +56,7 @@ var speakerBios = map[string]*component.Speaker{
 	},
 }
 
-var sessions = map[string]*component.Session{
+var sessions = map[string]*eve.Session{
 	"kickoff": {
 		Title:       "Test our Tools: Gno.land and Gnoland",
 		Description: "This is a kickoff of an internal beta.",
@@ -78,12 +78,12 @@ var sessions = map[string]*component.Session{
 var gnolandlaunch = &event.Event{
 	Name:           "Gnoland Launch Preplanning",
 	Location:       locations["gnowhere"],
-	Status:         component.EventScheduled,
-	AttendanceMode: component.OnlineEventAttendanceMode,
+	Status:         eve.EventScheduled,
+	AttendanceMode: eve.OnlineEventAttendanceMode,
 	StartDate:      time.Date(2025, 7, 14, 0, 0, 0, 0, time.UTC),
 	EndDate:        time.Date(2025, 8, 29, 0, 0, 0, 0, time.UTC),
 	Description:    "Join this event to become a beta tester for Gnoland, help us think about planning the launch, and provide feedback on the platform. \n\n This is a pre-planning event to gather ideas and feedback from the community.",
-	Sessions: []*component.Session{
+	Sessions: []*eve.Session{
 		sessions["kickoff"],
 		sessions["retro"],
 	},

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnopriv001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnopriv001/event.gno
@@ -45,8 +45,7 @@ func Render(path string) string {
 	// FIXME: component view is not working
 	case eve.HasQueryParam(q, "session"):
 		id := q.Get("session")
-		return id[0]
-		//s := evt.GetSession(string(id[0])) // REVIEW: why is id a slice?
+		s := evt.GetSession(string(id[0])) // REVIEW: why is id a slice?
 		return eve.RenderComponent(path, s)
 	case eve.HasQueryParam(q, "location"):
 		return eve.RenderComponent(path, evt.GetLocation(q.Get("location")))

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/index.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/index.gno
@@ -43,8 +43,9 @@ Our goal is to expose how blockchain enables exit from legacy systems of control
 var contact = `
 Review the topics below to see what resonates with you. We welcome all builders, thinkers, and communities who share our vision.
 
-If you wish to get involved, have ideas, or want to help organize future events, please create a github issue.` + component.Button("Add GitHub Issue", "https://github.com/BUIDLTHEFUTURE/events/issues/new") + `
-`
+If you wish to get involved, have ideas, or want to help organize future events, please create a github issue.
+
+` + component.Button("Add GitHub Issue", "https://github.com/BUIDLTHEFUTURE/events/issues/new")
 
 var topics = `
 

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
@@ -47,11 +47,15 @@ func (*App) LiveEvent() *event.Event {
 	return registry.GetEvent(registry.LiveEventId)
 }
 
-func (*App) RegisterEvent(evt *event.Event, opts map[string]interface{}) string {
-	registry.SetRenderOpts(opts)
-	id := registry.RegisterEvent(evt, opts)
+func (*App) PublishEvent(evt *event.Event, opts map[string]interface{}) string {
+	id := app.RegisterEvent(evt, opts)
 	registry.LiveEventId = id
 	return id
+}
+
+func (*App) RegisterEvent(evt *event.Event, opts map[string]interface{}) string {
+	registry.SetRenderOpts(opts)
+	return registry.RegisterEvent(evt, opts)
 }
 
 func (*App) AdminSetRole(role string, addr std.Address) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/app.gno
@@ -4,7 +4,7 @@ import (
 	"std"
 
 	"gno.land/p/eve000/event"
-	"gno.land/p/eve000/event/component"
+	eve "gno.land/p/eve000/event/component"
 )
 
 type App struct{}
@@ -23,7 +23,7 @@ func (*App) Render(path string) (out string) {
 }
 
 func (*App) RenderCalendar(path string) string {
-	return app.LiveEvent().Render(path, component.IcsCalendarFile)
+	return app.LiveEvent().Render(path, eve.IcsCalendarFile)
 }
 
 func (*App) SetContent(key, markdown string) {

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
@@ -25,7 +25,7 @@ var locations = map[string]*component.Location{
 	"null": {
 		Name:        "Null Island",
 		Coordinates: "0.0, 0.0",
-		Description: "*not an actual Island [![Null Island coords: 0, 0](https://cdn.jsdelivr.net/gh/BUIDLTHEFUTURE/events@main/static/img/null_island.png)](https://en.wikipedia.org/wiki/Null_Island)",
+		Description: "*not an actual Island \n\n[![Null Island coords: 0, 0](https://cdn.jsdelivr.net/gh/BUIDLTHEFUTURE/events@main/static/img/null_island.png)](https://en.wikipedia.org/wiki/Null_Island)",
 	},
 	"atx": {
 		Name:        "Austin, Texas",

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"gno.land/p/eve000/event"
-	"gno.land/p/eve000/event/component"
+	eve "gno.land/p/eve000/event/component"
 )
 
 func init() {
@@ -16,12 +16,12 @@ func init() {
 }
 
 // banner content block is shown in the top section of the event page
-var banner = component.Content{
+var banner = eve.Content{
 	Published: true,
 	Markdown:  "\n\n#### Status: Pre-planning",
 }
 
-var locations = map[string]*component.Location{
+var locations = map[string]*eve.Location{
 	"null": {
 		Name:        "Null Island",
 		Coordinates: "0.0, 0.0",
@@ -35,11 +35,11 @@ var locations = map[string]*component.Location{
 	},
 }
 
-var sessions = map[string]*component.Session{
+var sessions = map[string]*eve.Session{
 	"kickoff": {
 		Title:       "A Visit To Null Island",
 		Description: "Welcome to nowhere - there is nothing here, but we can still have a good time!",
-		Speaker:     &component.Speaker{},
+		Speaker:     &eve.Speaker{},
 		StartTime:   time.Date(2025, 7, 17, 13, 0, 0, 0, time.UTC),
 		EndTime:     time.Date(2025, 7, 17, 13, 30, 0, 0, time.UTC),
 		Location:    locations["null"],
@@ -47,7 +47,7 @@ var sessions = map[string]*component.Session{
 	"summit": {
 		Title:       "Summit in Austin",
 		Description: "Join us for a summit in Austin, Texas to discuss the future of Gnoland and how we can build it together.",
-		Speaker:     &component.Speaker{},
+		Speaker:     &eve.Speaker{},
 		StartTime:   time.Date(2025, 7, 18, 10, 0, 0, 0, time.UTC),
 		EndTime:     time.Date(2025, 7, 18, 17, 0, 0, 0, time.UTC),
 		Location:    locations["atx"],
@@ -59,10 +59,10 @@ var gnolandlaunch = &event.Event{
 	Location:       locations["gnowhere"],
 	StartDate:      time.Date(2025, 7, 14, 0, 0, 0, 0, time.UTC),
 	EndDate:        time.Date(2025, 8, 29, 0, 0, 0, 0, time.UTC),
-	Status:         component.EventMovedOnline, // it was planned as an IRL event example, but it was moved online ;-P
-	AttendanceMode: component.OfflineEventAttendanceMode,
+	Status:         eve.EventMovedOnline, // it was planned as an IRL event example, but it was moved online ;-P
+	AttendanceMode: eve.OfflineEventAttendanceMode,
 	Description:    "Join this event to become a beta tester for Gnoland, help us think about planning the launch, and provide feedback on the platform. \n\n This is a pre-planning event to gather ideas and feedback from the community.",
-	Sessions: []*component.Session{
+	Sessions: []*eve.Session{
 		sessions["kickoff"],
 		sessions["summit"],
 	},

--- a/projects/gnoland/gno.land/r/metamodel000/qwerty.gno
+++ b/projects/gnoland/gno.land/r/metamodel000/qwerty.gno
@@ -12,16 +12,15 @@ Though not overly useful in itself, it serves as a demonstration that inputs wit
 Thus, we can control a re-usable model vocabulary that can be built upon by appending arrows and places to the model.
 `
 var (
-    externalLink = `[![pflow](https://pflow.dev/img/zb2rhoVtN4MTsEuAEL6eMDog85mvLx91jG5LTnnDZ6fxxqVRb.svg)](https://pflow.dev/p/zb2rhoVtN4MTsEuAEL6eMDog85mvLx91jG5LTnnDZ6fxxqVRb/)`
+	externalLink = `[![pflow](https://pflow.dev/img/zb2rhoVtN4MTsEuAEL6eMDog85mvLx91jG5LTnnDZ6fxxqVRb.svg)](https://pflow.dev/p/zb2rhoVtN4MTsEuAEL6eMDog85mvLx91jG5LTnnDZ6fxxqVRb/)`
 )
-
 
 func init() {
 	keyboard := qwertyModel()
 	keyboard.Binding = func(_ string) string {
 		return qwertyNotes + keyboard.ToMarkdown() + externalLink
 	}
-    register("Keyboard", keyboard)
+	register("Keyboard", keyboard)
 }
 
 func qwertyModel() *mm.Model {


### PR DESCRIPTION
- addresses initialization issue when using event{} w/ the registry 
  - now init storage when SetRenderOpts() is called
  
 - Address image spacing changes from new gnoweb build
 - Splits PublishEvent/ RegisterEvent - allows user to add a 'non-live' event 