### PR TITLE
Feat/segement render opts by chain

### DIFF
--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -211,3 +211,17 @@ func (evt *Event) ToAnchor() string {
 func (evt *Event) Render(path string, tpl func(path string, flyer *eve.Flyer) string) string {
 	return tpl(path, evt.Flyer())
 }
+
+func (evt *Event) RenderPage(path string, body ...eve.Content) string {
+	q := eve.QueryValues(path)
+	switch {
+	case eve.HasQueryParam(q, "session"):
+		return eve.RenderComponent(path, evt.GetSession(q.Get("session")))
+	case eve.HasQueryParam(q, "location"):
+		return eve.RenderComponent(path, evt.GetLocation(q.Get("location")))
+	case eve.HasQueryParam(q, "speaker"):
+		return eve.RenderComponent(path, evt.GetSpeaker(q.Get("speaker")))
+	default:
+	}
+	return eve.RenderPage(path, evt.Flyer(), body...)
+}

--- a/projects/gnoland/gno.land/p/eve000/event/event.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/event.gno
@@ -187,14 +187,19 @@ func (evt *Event) initStorage() {
 }
 
 func (evt *Event) SetRenderOpts(opts map[string]interface{}) {
-	evt.renderOpts = opts
+	chainId := std.ChainID()
+	if _, ok := opts[chainId]; !ok {
+		panic("render options must be set for the current chain: " + chainId)
+	}
+	evt.renderOpts = opts[chainId].(map[string]interface{})
+
 	if evt.storage == nil {
 		evt.initStorage()
 	}
 	for _, s := range evt.Sessions {
-		s.SetRenderOpts(opts)
-		s.Speaker.SetRenderOpts(opts)
-		s.Location.SetRenderOpts(opts)
+		s.SetRenderOpts(evt.renderOpts)
+		s.Speaker.SetRenderOpts(evt.renderOpts)
+		s.Location.SetRenderOpts(evt.renderOpts)
 	}
 }
 

--- a/projects/gnoland/gno.land/p/eve000/event/registry.gno
+++ b/projects/gnoland/gno.land/p/eve000/event/registry.gno
@@ -43,16 +43,6 @@ func (r *Registry) Render(path string, body ...eve.Content) string {
 	}
 }
 
-func NewRegistry(renderOpts map[string]interface{}) *Registry {
-	return &Registry{
-		Events:      avl.NewTree(),
-		LiveEventId: "",
-		RenderOpts:  renderOpts,
-		patchLevel:  0,
-		patchRealm:  "",
-	}
-}
-
 func (r *Registry) GetPatchLevel() string {
 	realmLink := strings.TrimPrefix(r.patchRealm, "gno.land")
 	return ufmt.Sprintf("[rev %d](%s)", r.patchLevel, realmLink)
@@ -86,8 +76,7 @@ func (r *Registry) RegisterEvent(e *Event, opts map[string]interface{}) string {
 	if r.Events == nil {
 		r.Events = avl.NewTree()
 	}
-	e.SetRenderOpts(opts)
-
+	e.SetRenderOpts(opts) // REVIEW: consider moving this into the Event constructor
 	id := eve.Pad3(r.Events.Size())
 	r.Events.Set(id, e)
 	return id

--- a/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/TODO.md
@@ -3,7 +3,7 @@ WIP
 High level TODOs for eve
 
 - [ ] Focus on separation between Event -> Flyer objects for security and developer api
-- [ ] Refine ACL to make it more flexible between events
+- [ ] Refine ACL to make it more flexible between the different example events
 - [ ] Test /events api with all registered events
 - [ ] Audit for security issues with event permissions re: realm-based perms
 - [ ] add rendering tests for each type of supported event config location/speaker/cancelled events
@@ -22,7 +22,7 @@ BACKLOG
 - [ ] fix/test the `/events` api
 - [ ] consider refactoring acl.gno for each event's specific needs
 - [ ] review style of events in calendar (url encoded? Test+foo ?)
-- [ ] self-audit patch permissions for each event's realm - is exposing LiveEvent() bad?
+- [ ] self-audit patch permissions for each event's realm 
 - [ ] test content blocks with callbacks
  
 DONE

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnolandlaunch/event.gno
@@ -9,10 +9,12 @@ import (
 
 func init() {
 	renderOpts := map[string]interface{}{
-		"SvgFooter":       struct{}{},                // enables SVG footer in the event flyer
-		"CalendarHost":    "webcal://127.0.0.1:8080", // external webcal server
-		"CalendarFile":    "http://127.0.0.1:8080",   // external calendar file server
-		"CalendarDataUrl": struct{}{},                // allows use of calendar without external server
+		"dev": map[string]interface{}{
+			"SvgFooter":       struct{}{},                // enables SVG footer in the event flyer
+			"CalendarHost":    "webcal://127.0.0.1:8080", // external webcal server
+			"CalendarFile":    "http://127.0.0.1:8080",   // external calendar file server
+			"CalendarDataUrl": struct{}{},                // allows use of calendar without external server
+		},
 	}
 	app.RegisterEvent(gnolandlaunch, renderOpts)
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnoplan001/event.gno
@@ -9,9 +9,11 @@ import (
 
 func init() {
 	renderOpts := map[string]interface{}{
-		"Speaker":      struct{}{},
-		"SvgFooter":    struct{}{},
-		"CalendarHost": "webcal://127.0.0.1:8080",
+		"dev": map[string]interface{}{
+			"Speaker":      struct{}{},
+			"SvgFooter":    struct{}{},
+			"CalendarHost": "webcal://127.0.0.1:8080",
+		},
 	}
 	app.RegisterEvent(gnolandlaunch, renderOpts)
 }

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnopriv001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnopriv001/event.gno
@@ -43,21 +43,7 @@ var evt = &event.Event{
 }
 
 func Render(path string) string {
-	q := eve.QueryValues(path)
-	switch {
-	// FIXME: component view is not working
-	case eve.HasQueryParam(q, "session"):
-		id := q.Get("session")
-		s := evt.GetSession(string(id[0])) // REVIEW: why is id a slice?
-		return eve.RenderComponent(path, s)
-	case eve.HasQueryParam(q, "location"):
-		return eve.RenderComponent(path, evt.GetLocation(q.Get("location")))
-	case eve.HasQueryParam(q, "speaker"):
-		return eve.RenderComponent(path, evt.GetSpeaker(q.Get("speaker")))
-	default:
-		return eve.RenderPage(path, evt.Flyer(), banner)
-	}
-	return "Rendering failed: no valid query parameters found."
+	return evt.RenderPage(path, banner)
 }
 
 var locations = map[string]*eve.Location{

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/gnopriv001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/gnopriv001/event.gno
@@ -9,11 +9,14 @@ import (
 
 func init() {
 	evt.SetRenderOpts(map[string]interface{}{
-		"Speaker":         struct{}{},
-		"SvgFooter":       struct{}{},
-		"CalendarDataUrl": struct{}{},
-		//"CalendarHost": "webcal://127.0.0.1:8080",
+		"dev": map[string]interface{}{
+			"Speaker":         struct{}{},
+			"SvgFooter":       struct{}{},
+			"CalendarDataUrl": struct{}{},
+			//"CalendarHost": "webcal://127.0.0.1:8080",
+		},
 	})
+
 	// REVIEW: register the event with  the event registry
 	// reg "gno.land/r/buidlthefuture000/events/"
 	// events.RegisterEvent(evt, map[string]interface{}{

--- a/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
+++ b/projects/gnoland/gno.land/r/buidlthefuture000/events/onsite001/event.gno
@@ -9,8 +9,10 @@ import (
 
 func init() {
 	renderOpts := map[string]interface{}{
-		"SvgFooter": struct{}{},
-		"Location":  struct{}{},
+		"dev": map[string]interface{}{
+			"SvgFooter": struct{}{},
+			"Location":  struct{}{},
+		},
 	}
 	app.RegisterEvent(gnolandlaunch, renderOpts)
 }


### PR DESCRIPTION
- updates event.SetRenderOpts - to expect options to be segmented by chainId
- move event display logic into event.RenderPage()

TODO: use this new feature to control domains for calendar links 